### PR TITLE
Add required peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "devDependencies": {
     "autoprefixer": "6.5.1",
+    "babel-core": "^6.0.0",
     "babel-eslint": "7.0.0",
     "babel-loader": "6.2.5",
     "babel-plugin-transform-async-generator-functions": "^6.22.0",


### PR DESCRIPTION
### Steps to reproduce
```
$ npm install
...
npm WARN babel-loader@6.2.5 requires a peer of babel-core@^6.0.0 but none was installed
$ npm start
...
Failed to compile.

Error in Cannot find module 'babel-core'
 @ multi main
```

### Configuration
npm: 4.6.1

### RCA
From [_SO_](https://stackoverflow.com/a/40805636):
> The reason behind this is that npm deprecated auto-installing of peerDependencies since npm@3, so required peer dependencies like babel-core and webpack must be listed explicitly in your package.json.