### PR TITLE
name exported PDF according to layer, zoom and page size

### DIFF
--- a/src/layers.js
+++ b/src/layers.js
@@ -20,6 +20,7 @@ export default function getLayers() {
                 {
                     title: 'OpenStreetMap',
                     description: 'OSM default style',
+                    shortName: 'osm',
                     order: 100,
                     isOverlay: false,
                     isDefault: true,
@@ -29,6 +30,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'ESRI Sat',
+                    shortName: 'esri',
                     order: 200,
                     isOverlay: false,
                     isDefault: true,
@@ -39,6 +41,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Yandex map',
+                    shortName: 'yandex',
                     order: 300,
                     isOverlay: false,
                     isDefault: true,
@@ -46,6 +49,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Yandex Satellite',
+                    shortName: 'yandex_sat',
                     order: 400,
                     isOverlay: false,
                     isDefault: true,
@@ -53,6 +57,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Google',
+                    shortName: 'google',
                     order: 500,
                     isOverlay: false,
                     isDefault: true,
@@ -60,6 +65,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Google Satellite',
+                    shortName: 'google_sat',
                     order: 600,
                     isOverlay: false,
                     isDefault: true,
@@ -67,6 +73,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Google Terrain',
+                    shortName: 'google_terrain',
                     order: 650,
                     isOverlay: false,
                     isDefault: true,
@@ -74,6 +81,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Bing Sat',
+                    shortName: 'bing',
                     order: 700,
                     isOverlay: false,
                     isDefault: true,
@@ -82,6 +90,7 @@ export default function getLayers() {
 
                 {
                     title: 'marshruty.ru',
+                    shortName: 'marshruty',
                     order: 800,
                     isOverlay: false,
                     isDefault: true,
@@ -91,6 +100,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Topomapper 1km',
+                    shortName: 'topomapper_1k',
                     order: 900,
                     isOverlay: false,
                     isDefault: true,
@@ -102,6 +112,7 @@ export default function getLayers() {
 
                 {
                     title: 'Topo 10km',
+                    shortName: 'topo_10k',
                     order: 10100,
                     isOverlay: true,
                     isDefault: true,
@@ -111,6 +122,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'GGC 2 km',
+                    shortName: 'ggc_2k',
                     order: 10200,
                     isOverlay: true,
                     isDefault: true,
@@ -120,6 +132,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'ArbaletMO',
+                    shortName: 'arbalet',
                     order: 10300,
                     isOverlay: true,
                     isDefault: true,
@@ -129,6 +142,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Slazav mountains',
+                    shortName: 'slazav_mountains',
                     order: 10400,
                     isOverlay: true,
                     isDefault: true,
@@ -138,6 +152,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'GGC 1km',
+                    shortName: 'ggc_1k',
                     order: 10500,
                     isOverlay: true,
                     isDefault: true,
@@ -147,6 +162,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Topo 1km',
+                    shortName: 'topo_1k',
                     order: 10600,
                     isOverlay: true,
                     isDefault: true,
@@ -156,6 +172,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'GGC 500m',
+                    shortName: 'ggc_500',
                     order: 10700,
                     isOverlay: true,
                     isDefault: true,
@@ -165,6 +182,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Topo 500m',
+                    shortName: 'topo_500',
                     order: 10800,
                     isOverlay: true,
                     isDefault: true,
@@ -174,6 +192,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'GGC 250m',
+                    shortName: 'ggc_250',
                     order: 10900,
                     isOverlay: true,
                     isDefault: true,
@@ -183,6 +202,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Slazav map',
+                    shortName: 'slazav',
                     order: 11000,
                     isOverlay: true,
                     isDefault: true,
@@ -192,8 +212,10 @@ export default function getLayers() {
                 },
                 {
                     title: 'Races',
+                    shortName: 'races',
                     order: 11050,
                     isOverlay: true,
+                    isOverlayTransparent: true,
                     isDefault: true,
                     layer: L.tileLayer("https://tiles.nakarte.tk/adraces/{z}/{x}/{y}",
                         {code: 'U', tms: true, scaleDependent: false, maxNativeZoom: 15, print: true, jnx: true}
@@ -201,8 +223,10 @@ export default function getLayers() {
                 },
                 {
                     title: 'O-sport',
+                    shortName: 'osport',
                     order: 11100,
                     isOverlay: true,
+                    isOverlayTransparent: true,
                     isDefault: true,
                     layer: L.tileLayer("https://tiles.nakarte.tk/osport/{z}/{x}/{y}",
                         {code: 'R', tms: true, scaleDependent: false, maxNativeZoom: 17, print: true, jnx: true}
@@ -210,6 +234,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Soviet topo maps grid',
+                    shortName: 'soviet_topo_grid',
                     order: 11200,
                     isOverlay: true,
                     isDefault: true,
@@ -217,6 +242,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Wikimapia',
+                    shortName: 'wikimapia',
                     order: 11300,
                     isOverlay: true,
                     isDefault: true,
@@ -224,8 +250,10 @@ export default function getLayers() {
                 },
                 {
                     title: 'Mountain passes (Westra)',
+                    shortName: 'westra',
                     order: 11400,
                     isOverlay: true,
+                    isOverlayTransparent: true,
                     isDefault: true,
                     layer: new L.Layer.WestraPasses(config.westraDataBaseUrl, {
                             code: 'Wp',
@@ -254,6 +282,7 @@ export default function getLayers() {
             layers: [
                 {
                     title: 'OpenTopoMap',
+                    shortName: 'opentopo',
                     order: 110,
                     isOverlay: false,
                     isDefault: false,
@@ -263,6 +292,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'OpenCycleMap',
+                    shortName: 'ocm',
                     description: '<a href="https://www.opencyclemap.org/docs/">(Info and key)</a>',
                     order: 120,
                     isOverlay: false,
@@ -273,6 +303,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'OSM Outdoors',
+                    shortName: 'osm_outdoors',
                     order: 130,
                     isOverlay: false,
                     isDefault: false,
@@ -287,6 +318,7 @@ export default function getLayers() {
             layers: [
                 {
                     title: 'Eurasia 25km',
+                    shortName: 'eurasia_25k',
                     description: '1975-80',
                     order: 10090,
                     isOverlay: true,
@@ -297,6 +329,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Caucasus 1km',
+                    shortName: 'caucasus_1k',
                     order: 10610,
                     isOverlay: true,
                     isDefault: false,
@@ -306,6 +339,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Caucasus 500m',
+                    shortName: 'caucasus_500',
                     order: 10810,
                     isOverlay: true,
                     isDefault: false,
@@ -315,6 +349,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Topo 250m',
+                    shortName: 'topo_250',
                     order: 10950,
                     isOverlay: true,
                     isDefault: false,
@@ -324,6 +359,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Montenegro topo 250m',
+                    shortName: 'montenegro_250',
                     description: '1970-72',
                     order: 10960,
                     isOverlay: true,
@@ -339,6 +375,7 @@ export default function getLayers() {
             layers: [
                 {
                     title: 'Mountains by Aleksey Tsvetkov',
+                    shortName: 'tsvetkov_mountains',
                     description: 'Tian Shan, Dzungaria, <a href="http://pereval.g-utka.ru/">http://pereval.g-utka.ru/</a>',
                     order: 10390,
                     isOverlay: true,
@@ -364,6 +401,7 @@ export default function getLayers() {
             layers: [
                 {
                     title: 'Bing imagery acquisition dates',
+                    shortName: 'bind_dates',
                     order: 11110,
                     isOverlay: true,
                     isDefault: false,
@@ -378,6 +416,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'geocaching.su',
+                    shortName: 'geocaching',
                     order: 11500,
                     isOverlay: true,
                     isDefault: false,
@@ -389,6 +428,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'OpenStreetMap GPS traces',
+                    shortName: 'osm_gps_traces',
                     order: 11120,
                     isOverlay: true,
                     isDefault: false,
@@ -398,6 +438,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Strava heatmap (all)',
+                    shortName: 'strava',
                     order: 11130,
                     isOverlay: true,
                     isDefault: false,
@@ -408,6 +449,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Strava heatmap (run)',
+                    shortName: 'strava_run',
                     order: 11131,
                     isOverlay: true,
                     isDefault: false,
@@ -418,6 +460,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Strava heatmap (ride)',
+                    shortName: 'strava_ride',
                     order: 11132,
                     isOverlay: true,
                     isDefault: false,
@@ -428,6 +471,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Strava heatmap (winter)',
+                    shortName: 'strava_winter',
                     order: 11133,
                     isOverlay: true,
                     isDefault: false,
@@ -438,6 +482,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Strava heatmap lowres (all)',
+                    shortName: 'strava_lowres',
                     order: 11134,
                     isOverlay: true,
                     isDefault: false,
@@ -448,6 +493,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Strava heatmap lowres (run)',
+                    shortName: 'strava_lowres_run',
                     order: 11135,
                     isOverlay: true,
                     isDefault: false,
@@ -458,6 +504,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Strava heatmap lowres (ride)',
+                    shortName: 'strava_lowres_ride',
                     order: 11136,
                     isOverlay: true,
                     isDefault: false,
@@ -468,6 +515,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Strava heatmap lowres (winter)',
+                    shortName: 'strava_lowres_winter',
                     order: 11137,
                     isOverlay: true,
                     isDefault: false,
@@ -485,6 +533,7 @@ export default function getLayers() {
                 {
                     // Вместо 404 отдают 500 для отсутствующих тайлов
                     title: 'Norway UT map',
+                    shortName: 'norway_ut',
                     order: 5000,
                     isOverlay: false,
                     isDefault: false,
@@ -494,6 +543,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Norway paper map',
+                    shortName: 'norway_paper',
                     order: 10310,
                     isOverlay: true,
                     isDefault: false,
@@ -503,6 +553,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Norway map',
+                    shortName: 'norway',
                     order: 10320,
                     isOverlay: true,
                     isDefault: false,
@@ -512,6 +563,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Norway summer trails',
+                    shortName: 'norway_summer',
                     order: 20000,
                     isOverlay: true,
                     isDefault: false,
@@ -521,6 +573,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Norway winter trails',
+                    shortName: 'norway_winter',
                     order: 20010,
                     isOverlay: true,
                     isDefault: false,
@@ -531,6 +584,7 @@ export default function getLayers() {
                 {
                     // Вместо 404 отдают 500 для отсутствующих тайлов
                     title: 'Norway roads',
+                    shortName: 'norway_roads',
                     description: '<a href="https://kart.finn.no/">https://kart.finn.no/</a>',
                     order: 5030,
                     isOverlay: false,
@@ -545,6 +599,7 @@ export default function getLayers() {
             layers: [
                 {
                     title: 'Czech base',
+                    shortName: 'czech',
                     order: 5040,
                     isOverlay: false,
                     isDefault: false,
@@ -554,6 +609,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Czech tourist',
+                    shortName: 'czech_tourist',
                     order: 5050,
                     isOverlay: false,
                     isDefault: false,
@@ -563,6 +619,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Czech summer',
+                    shortName: 'czech_summer',
                     order: 5060,
                     isOverlay: false,
                     isDefault: false,
@@ -572,6 +629,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Czech winter',
+                    shortName: 'czech_winter',
                     order: 5070,
                     isOverlay: false,
                     isDefault: false,
@@ -581,6 +639,7 @@ export default function getLayers() {
                 },
                 {
                     title: 'Czech geographical',
+                    shortName: 'czech_geo',
                     order: 5080,
                     isOverlay: false,
                     isDefault: false,
@@ -593,6 +652,7 @@ export default function getLayers() {
     // TODO: move it to tests
     const codes = {};
     const orders = {};
+    const shortNames = new Set();
     for (let group of layers) {
         for (let layer of group.layers) {
             if (!layer.layer.options) {
@@ -614,6 +674,14 @@ export default function getLayers() {
                 throw new Error(`Duplicate layer order "${order}"`);
             }
             orders[order] = 1;
+            let shortName = layer.shortName;
+            if (!shortName) {
+                throw new Error('Layer without shortName: ' + layer.title);
+            }
+            if (shortNames.has(shortName)) {
+                throw new Error(`Duplicate layer shortName "${shortName}"`);
+            }
+            shortNames.add(shortName);
         }
     }
     return layers;

--- a/src/layers.js
+++ b/src/layers.js
@@ -20,245 +20,390 @@ export default function getLayers() {
                 {
                     title: 'OpenStreetMap',
                     description: 'OSM default style',
-                    shortName: 'osm',
                     order: 100,
-                    isOverlay: false,
                     isDefault: true,
                     layer: L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-                        {code: 'O', scaleDependent: true, print: true, jnx: true}
+                        {
+                            code: 'O',
+                            scaleDependent: true,
+                            print: true,
+                            jnx: true,
+                            shortName: 'osm'
+                        }
                     )
                 },
                 {
                     title: 'ESRI Sat',
-                    shortName: 'esri',
                     order: 200,
-                    isOverlay: false,
                     isDefault: true,
                     layer: L.tileLayer(
                         'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
-                        {code: 'E', scaleDependent: false, maxNativeZoom: 18, print: true, jnx: true}
+                        {
+                            code: 'E',
+                            scaleDependent: false,
+                            maxNativeZoom: 18,
+                            print: true,
+                            jnx: true,
+                            shortName: 'esri'
+                        }
                     )
                 },
                 {
                     title: 'Yandex map',
-                    shortName: 'yandex',
                     order: 300,
-                    isOverlay: false,
                     isDefault: true,
-                    layer: new L.Layer.Yandex('map', {scaleDependent: true, code: 'Y', print: true, jnx: true})
+                    layer: new L.Layer.Yandex('map',
+                        {
+                            scaleDependent: true,
+                            code: 'Y',
+                            print: true,
+                            jnx: true,
+                            shortName: 'yandex'
+                        }
+                    )
                 },
                 {
                     title: 'Yandex Satellite',
-                    shortName: 'yandex_sat',
                     order: 400,
-                    isOverlay: false,
                     isDefault: true,
-                    layer: new L.Layer.Yandex('sat', {scaleDependent: false, code: 'S', print: true, jnx: true})
+                    layer: new L.Layer.Yandex('sat',
+                        {
+                            scaleDependent: false,
+                            code: 'S',
+                            print: true,
+                            jnx: true,
+                            shortName: 'yandex_sat'
+                        }
+                    )
                 },
                 {
                     title: 'Google',
-                    shortName: 'google',
                     order: 500,
-                    isOverlay: false,
                     isDefault: true,
-                    layer: new L.Layer.Google('ROADMAP', {code: 'G', scaleDependent: true, print: true, jnx: true})
+                    layer: new L.Layer.Google('ROADMAP',
+                        {
+                            code: 'G',
+                            scaleDependent: true,
+                            print: true,
+                            jnx: true,
+                            shortName: 'google'
+                        }
+                    )
                 },
                 {
                     title: 'Google Satellite',
-                    shortName: 'google_sat',
                     order: 600,
-                    isOverlay: false,
                     isDefault: true,
-                    layer: new L.Layer.Google('SATELLITE', {code: 'L', scaleDependent: false, print: true, jnx: true})
+                    layer: new L.Layer.Google('SATELLITE',
+                        {
+                            code: 'L',
+                            scaleDependent: false,
+                            print: true,
+                            jnx: true,
+                            shortName: 'google_sat'
+                        }
+                    )
                 },
                 {
                     title: 'Google Terrain',
-                    shortName: 'google_terrain',
                     order: 650,
-                    isOverlay: false,
                     isDefault: true,
-                    layer: new L.Layer.Google('TERRAIN', {code: 'P', scaleDependent: false, print: true, jnx: true})
+                    layer: new L.Layer.Google('TERRAIN',
+                        {
+                            code: 'P',
+                            scaleDependent: false,
+                            print: true,
+                            jnx: true,
+                            shortName: 'google_terrain'
+                        }
+                    )
                 },
                 {
                     title: 'Bing Sat',
-                    shortName: 'bing',
                     order: 700,
-                    isOverlay: false,
                     isDefault: true,
-                    layer: new BingLayer(config.bingKey, {code: 'I', scaleDependent: false, print: true, jnx: true})
+                    layer: new BingLayer(config.bingKey,
+                        {
+                            code: 'I',
+                            scaleDependent: false,
+                            print: true,
+                            jnx: true,
+                            shortName: 'bing'
+                        }
+                    )
                 },
 
                 {
                     title: 'marshruty.ru',
-                    shortName: 'marshruty',
                     order: 800,
-                    isOverlay: false,
                     isDefault: true,
                     layer: L.tileLayer('https://maps.marshruty.ru/ml.ashx?x={x}&y={y}&z={z}&i=1&al=1',
-                        {code: 'M', maxNativeZoom: 18, noCors: true, scaleDependent: true, print: true, jnx: true}
+                        {
+                            code: 'M',
+                            maxNativeZoom: 18,
+                            noCors: true,
+                            scaleDependent: true,
+                            print: true,
+                            jnx: true,
+                            shortName: 'marshruty'
+                        }
                     )
                 },
                 {
                     title: 'Topomapper 1km',
-                    shortName: 'topomapper_1k',
                     order: 900,
-                    isOverlay: false,
                     isDefault: true,
                     layer: L.tileLayer(
                         'http://144.76.234.108/cgi-bin/tapp/tilecache.py/1.0.0/topomapper_v2/{z}/{x}/{y}.jpg',
-                        {code: 'T', scaleDependent: false, maxNativeZoom: 13, noCors: true, print: true, jnx: true}
+                        {
+                            code: 'T',
+                            scaleDependent: false,
+                            maxNativeZoom: 13,
+                            noCors: true,
+                            print: true,
+                            jnx: true,
+                            shortName: 'topomapper_1k'
+                        }
                     )
                 },
 
                 {
                     title: 'Topo 10km',
-                    shortName: 'topo_10k',
                     order: 10100,
-                    isOverlay: true,
                     isDefault: true,
                     layer: L.tileLayer("https://tiles.nakarte.tk/topo001m/{z}/{x}/{y}",
-                        {code: 'D', tms: true, scaleDependent: false, maxNativeZoom: 9, print: true, jnx: true}
+                        {
+                            code: 'D',
+                            isOverlay: true,
+                            tms: true,
+                            scaleDependent: false,
+                            maxNativeZoom: 9,
+                            print: true,
+                            jnx: true,
+                            shortName: 'topo_10k'
+                        }
                     )
                 },
                 {
                     title: 'GGC 2 km',
-                    shortName: 'ggc_2k',
                     order: 10200,
-                    isOverlay: true,
                     isDefault: true,
                     layer: L.tileLayer("https://tiles.nakarte.tk/ggc2000/{z}/{x}/{y}",
-                        {code: 'N', tms: true, scaleDependent: false, maxNativeZoom: 12, print: true, jnx: true}
+                        {
+                            code: 'N',
+                            isOverlay: true,
+                            tms: true,
+                            scaleDependent: false,
+                            maxNativeZoom: 12,
+                            print: true,
+                            jnx: true,
+                            shortName: 'ggc_2k'
+                        }
                     )
                 },
                 {
                     title: 'ArbaletMO',
-                    shortName: 'arbalet',
                     order: 10300,
-                    isOverlay: true,
                     isDefault: true,
                     layer: L.tileLayer("https://tiles.nakarte.tk/ArbaletMO/{z}/{x}/{y}",
-                        {code: 'A', tms: true, scaleDependent: false, maxNativeZoom: 13, print: true, jnx: true}
+                        {
+                            code: 'A',
+                            isOverlay: true,
+                            tms: true,
+                            scaleDependent: false,
+                            maxNativeZoom: 13,
+                            print: true,
+                            jnx: true,
+                            shortName: 'arbalet'
+                        }
                     )
                 },
                 {
                     title: 'Slazav mountains',
-                    shortName: 'slazav_mountains',
                     order: 10400,
-                    isOverlay: true,
                     isDefault: true,
                     layer: L.tileLayer("https://tiles.nakarte.tk/map_hr/{z}/{x}/{y}",
-                        {code: 'Q', tms: true, scaleDependent: false, maxNativeZoom: 13, print: true, jnx: true}
+                        {
+                            code: 'Q',
+                            isOverlay: true,
+                            tms: true,
+                            scaleDependent: false,
+                            maxNativeZoom: 13,
+                            print: true,
+                            jnx: true,
+                            shortName: 'slazav_mountains'
+                        }
                     )
                 },
                 {
                     title: 'GGC 1km',
-                    shortName: 'ggc_1k',
                     order: 10500,
-                    isOverlay: true,
                     isDefault: true,
                     layer: L.tileLayer("https://tiles.nakarte.tk/ggc1000/{z}/{x}/{y}",
-                        {code: 'J', tms: true, scaleDependent: false, maxNativeZoom: 13, print: true, jnx: true}
+                        {
+                            code: 'J',
+                            isOverlay: true,
+                            tms: true,
+                            scaleDependent: false,
+                            maxNativeZoom: 13,
+                            print: true,
+                            jnx: true,
+                            shortName: 'ggc_1k'
+                        }
                     )
                 },
                 {
                     title: 'Topo 1km',
-                    shortName: 'topo_1k',
                     order: 10600,
-                    isOverlay: true,
                     isDefault: true,
                     layer: L.tileLayer("https://tiles.nakarte.tk/topo1000/{z}/{x}/{y}",
-                        {code: 'C', tms: true, scaleDependent: false, maxNativeZoom: 13, print: true, jnx: true}
+                        {
+                            code: 'C',
+                            isOverlay: true,
+                            tms: true,
+                            scaleDependent: false,
+                            maxNativeZoom: 13,
+                            print: true,
+                            jnx: true,
+                            shortName: 'topo_1k'
+                        }
                     )
                 },
                 {
                     title: 'GGC 500m',
-                    shortName: 'ggc_500',
                     order: 10700,
-                    isOverlay: true,
                     isDefault: true,
                     layer: L.tileLayer("https://tiles.nakarte.tk/ggc500/{z}/{x}/{y}",
-                        {code: 'F', tms: true, scaleDependent: false, maxNativeZoom: 14, print: true, jnx: true}
+                        {
+                            code: 'F',
+                            isOverlay: true,
+                            tms: true,
+                            scaleDependent: false,
+                            maxNativeZoom: 14,
+                            print: true,
+                            jnx: true,
+                            shortName: 'ggc_500'
+                        }
                     )
                 },
                 {
                     title: 'Topo 500m',
-                    shortName: 'topo_500',
                     order: 10800,
-                    isOverlay: true,
                     isDefault: true,
                     layer: L.tileLayer("https://tiles.nakarte.tk/topo500/{z}/{x}/{y}",
-                        {code: 'B', tms: true, scaleDependent: false, maxNativeZoom: 14, print: true, jnx: true}
+                        {
+                            code: 'B',
+                            isOverlay: true,
+                            tms: true,
+                            scaleDependent: false,
+                            maxNativeZoom: 14,
+                            print: true,
+                            jnx: true,
+                            shortName: 'topo_500'
+                        }
                     )
                 },
                 {
                     title: 'GGC 250m',
-                    shortName: 'ggc_250',
                     order: 10900,
-                    isOverlay: true,
                     isDefault: true,
                     layer: L.tileLayer("https://tiles.nakarte.tk/ggc250/{z}/{x}/{y}",
-                        {code: 'K', tms: true, scaleDependent: false, maxNativeZoom: 15, print: true, jnx: true}
+                        {
+                            code: 'K',
+                            isOverlay: true,
+                            tms: true,
+                            scaleDependent: false,
+                            maxNativeZoom: 15,
+                            print: true,
+                            jnx: true,
+                            shortName: 'ggc_250'
+                        }
                     )
                 },
                 {
                     title: 'Slazav map',
-                    shortName: 'slazav',
                     order: 11000,
-                    isOverlay: true,
                     isDefault: true,
                     layer: L.tileLayer("https://tiles.nakarte.tk/map_podm/{z}/{x}/{y}",
-                        {code: 'Z', tms: true, scaleDependent: false, maxNativeZoom: 14, print: true, jnx: true}
+                        {
+                            code: 'Z',
+                            isOverlay: true,
+                            tms: true,
+                            scaleDependent: false,
+                            maxNativeZoom: 14,
+                            print: true,
+                            jnx: true,
+                            shortName: 'slazav'
+                        }
                     )
                 },
                 {
                     title: 'Races',
-                    shortName: 'races',
                     order: 11050,
-                    isOverlay: true,
-                    isOverlayTransparent: true,
                     isDefault: true,
                     layer: L.tileLayer("https://tiles.nakarte.tk/adraces/{z}/{x}/{y}",
-                        {code: 'U', tms: true, scaleDependent: false, maxNativeZoom: 15, print: true, jnx: true}
+                        {
+                            code: 'U',
+                            isOverlay: true,
+                            isOverlayTransparent: true,
+                            tms: true,
+                            scaleDependent: false,
+                            maxNativeZoom: 15,
+                            print: true,
+                            jnx: true,
+                            shortName: 'races'
+                        }
                     )
                 },
                 {
                     title: 'O-sport',
-                    shortName: 'osport',
                     order: 11100,
-                    isOverlay: true,
-                    isOverlayTransparent: true,
                     isDefault: true,
                     layer: L.tileLayer("https://tiles.nakarte.tk/osport/{z}/{x}/{y}",
-                        {code: 'R', tms: true, scaleDependent: false, maxNativeZoom: 17, print: true, jnx: true}
+                        {
+                            code: 'R',
+                            isOverlay: true,
+                            isOverlayTransparent: true,
+                            tms: true,
+                            scaleDependent: false,
+                            maxNativeZoom: 17,
+                            print: true,
+                            jnx: true,
+                            shortName: 'osport'
+                        }
                     )
                 },
                 {
                     title: 'Soviet topo maps grid',
-                    shortName: 'soviet_topo_grid',
                     order: 11200,
-                    isOverlay: true,
                     isDefault: true,
-                    layer: new L.Layer.SovietTopoGrid({code: 'Ng'})
+                    layer: new L.Layer.SovietTopoGrid({
+                        code: 'Ng',
+                        isOverlay: true,
+                        shortName: 'soviet_topo_grid'
+                    })
                 },
                 {
                     title: 'Wikimapia',
-                    shortName: 'wikimapia',
                     order: 11300,
-                    isOverlay: true,
                     isDefault: true,
-                    layer: new L.Wikimapia({code: 'W'}),
+                    layer: new L.Wikimapia({
+                        code: 'W',
+                        isOverlay: true,
+                        shortName: 'wikimapia'
+                    })
                 },
                 {
                     title: 'Mountain passes (Westra)',
-                    shortName: 'westra',
                     order: 11400,
-                    isOverlay: true,
-                    isOverlayTransparent: true,
                     isDefault: true,
                     layer: new L.Layer.WestraPasses(config.westraDataBaseUrl, {
                             code: 'Wp',
+                            isOverlay: true,
+                            isOverlayTransparent: true,
                             print: true,
-                            scaleDependent: true
+                            scaleDependent: true,
+                            shortName: 'westra'
                         }
                     )
                 },
@@ -282,33 +427,47 @@ export default function getLayers() {
             layers: [
                 {
                     title: 'OpenTopoMap',
-                    shortName: 'opentopo',
                     order: 110,
-                    isOverlay: false,
                     isDefault: false,
                     layer: L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png',
-                        {code: 'Otm', maxNativeZoom: 17, scaleDependent: true, print: true, jnx: true, noCors: false}
+                        {
+                            code: 'Otm',
+                            maxNativeZoom: 17,
+                            scaleDependent: true,
+                            print: true,
+                            jnx: true,
+                            noCors: false,
+                            shortName: 'opentopo'
+                        }
                     )
                 },
                 {
                     title: 'OpenCycleMap',
-                    shortName: 'ocm',
                     description: '<a href="https://www.opencyclemap.org/docs/">(Info and key)</a>',
                     order: 120,
-                    isOverlay: false,
                     isDefault: false,
                     layer: L.tileLayer('https://{s}.tile.thunderforest.com/cycle/{z}/{x}/{y}.png?apikey=' + config.thunderforestKey,
-                        {code: 'Ocm', scaleDependent: true, print: true, jnx: true}
+                        {
+                            code: 'Ocm',
+                            scaleDependent: true,
+                            print: true,
+                            jnx: true,
+                            shortName: 'ocm'
+                        }
                     )
                 },
                 {
                     title: 'OSM Outdoors',
-                    shortName: 'osm_outdoors',
                     order: 130,
-                    isOverlay: false,
                     isDefault: false,
                     layer: L.tileLayer('https://{s}.tile.thunderforest.com/outdoors/{z}/{x}/{y}.png?apikey=' + config.thunderforestKey,
-                        {code: 'Oso', scaleDependent: true, print: true, jnx: true}
+                        {
+                            code: 'Oso',
+                            scaleDependent: true,
+                            print: true,
+                            jnx: true,
+                            shortName: 'osm_outdoors'
+                        }
                     )
                 },
             ]
@@ -318,54 +477,89 @@ export default function getLayers() {
             layers: [
                 {
                     title: 'Eurasia 25km',
-                    shortName: 'eurasia_25k',
                     description: '1975-80',
                     order: 10090,
-                    isOverlay: true,
                     isDefault: false,
                     layer: L.tileLayer("https://tiles.nakarte.tk/eurasia25km/{z}/{x}/{y}",
-                        {code: 'E25m', tms: true, maxNativeZoom: 9, print: true, jnx: true, scaleDependent: false}
+                        {
+                            code: 'E25m',
+                            isOverlay: true,
+                            tms: true,
+                            maxNativeZoom: 9,
+                            print: true,
+                            jnx: true,
+                            scaleDependent: false,
+                            shortName: 'eurasia_25k'
+                        }
                     )
                 },
                 {
                     title: 'Caucasus 1km',
-                    shortName: 'caucasus_1k',
                     order: 10610,
-                    isOverlay: true,
                     isDefault: false,
                     layer: L.tileLayer("https://tiles.nakarte.tk/new_gsh_100k/{z}/{x}/{y}",
-                        {code: 'NT1', tms: true, maxNativeZoom: 14, print: true, jnx: true, scaleDependent: false}
+                        {
+                            code: 'NT1',
+                            isOverlay: true,
+                            tms: true,
+                            maxNativeZoom: 14,
+                            print: true,
+                            jnx: true,
+                            scaleDependent: false,
+                            shortName: 'caucasus_1k'
+                        }
                     )
                 },
                 {
                     title: 'Caucasus 500m',
-                    shortName: 'caucasus_500',
                     order: 10810,
-                    isOverlay: true,
                     isDefault: false,
                     layer: L.tileLayer("https://tiles.nakarte.tk/new_gsh_050k/{z}/{x}/{y}",
-                        {code: 'NT5', tms: true, maxNativeZoom: 15, print: true, jnx: true, scaleDependent: false}
+                        {
+                            code: 'NT5',
+                            isOverlay: true,
+                            tms: true,
+                            maxNativeZoom: 15,
+                            print: true,
+                            jnx: true,
+                            scaleDependent: false,
+                            shortName: 'caucasus_500'
+                        }
                     )
                 },
                 {
                     title: 'Topo 250m',
-                    shortName: 'topo_250',
                     order: 10950,
-                    isOverlay: true,
                     isDefault: false,
                     layer: L.tileLayer("https://tiles.nakarte.tk/topo250/{z}/{x}/{y}",
-                        {code: 'T25', tms: true, maxNativeZoom: 15, print: true, jnx: true, scaleDependent: false}
+                        {
+                            code: 'T25',
+                            isOverlay: true,
+                            tms: true,
+                            maxNativeZoom: 15,
+                            print: true,
+                            jnx: true,
+                            scaleDependent: false,
+                            shortName: 'topo_250'
+                        }
                     )
                 },
                 {
                     title: 'Montenegro topo 250m',
-                    shortName: 'montenegro_250',
                     description: '1970-72',
                     order: 10960,
-                    isOverlay: true,
                     isDefault: false,
                     layer: L.tileLayer("https://tiles.nakarte.tk/montenegro250m/{z}/{x}/{y}",
-                        {code: 'MN25', tms: true, maxNativeZoom: 15, print: true, jnx: true, scaleDependent: false}
+                        {
+                            code: 'MN25',
+                            isOverlay: true,
+                            tms: true,
+                            maxNativeZoom: 15,
+                            print: true,
+                            jnx: true,
+                            scaleDependent: false,
+                            shortName: 'montenegro_250'
+                        }
                     )
                 }
             ]
@@ -375,15 +569,14 @@ export default function getLayers() {
             layers: [
                 {
                     title: 'Mountains by Aleksey Tsvetkov',
-                    shortName: 'tsvetkov_mountains',
                     description: 'Tian Shan, Dzungaria, <a href="http://pereval.g-utka.ru/">http://pereval.g-utka.ru/</a>',
                     order: 10390,
-                    isOverlay: true,
                     isDefault: false,
                     layer: L.tileLayer("http://map.g-utka.ru/{z}/{x}/{y}.png",
                         // FIXME: сделать minZoom=5, когда перейдём на версию leaflet с поддержкой minNativeZoom
                         {
                             code: 'Mt',
+                            isOverlay: true,
                             tms: false,
                             minZoom: 7,
                             minNativeZoom: 7,
@@ -391,7 +584,8 @@ export default function getLayers() {
                             print: true,
                             jnx: true,
                             scaleDependent: false,
-                            noCors: true
+                            noCors: true,
+                            shortName: 'tsvetkov_mountains'
                         }
                     )
                 }]
@@ -401,12 +595,11 @@ export default function getLayers() {
             layers: [
                 {
                     title: 'Bing imagery acquisition dates',
-                    shortName: 'bind_dates',
                     order: 11110,
-                    isOverlay: true,
                     isDefault: false,
                     layer: new BingDates({
                         code: 'Bd',
+                        isOverlay: true,
                         maxNativeZoom: 18,
                         print: false,
                         jnx: false,
@@ -416,112 +609,165 @@ export default function getLayers() {
                 },
                 {
                     title: 'geocaching.su',
-                    shortName: 'geocaching',
                     order: 11500,
-                    isOverlay: true,
                     isDefault: false,
                     layer: new GeocachingSu(config.geocachingSuUrl, {
                         code: 'Gc',
+                        isOverlay: true,
                         print: true,
-                        jnx: false
+                        jnx: false,
+                        shortName: 'geocaching'
                     })
                 },
                 {
                     title: 'OpenStreetMap GPS traces',
-                    shortName: 'osm_gps_traces',
                     order: 11120,
-                    isOverlay: true,
                     isDefault: false,
                     layer: L.tileLayer('https://{s}.gps-tile.openstreetmap.org/lines/{z}/{x}/{y}.png',
-                        {code: 'Ot', scaleDependent: true, print: true, jnx: false}
+                        {
+                            code: 'Ot',
+                            isOverlay: true,
+                            scaleDependent: true,
+                            print: true,
+                            jnx: false,
+                            shortName: 'osm_gps_traces'
+                        }
                     )
                 },
                 {
                     title: 'Strava heatmap (all)',
-                    shortName: 'strava',
                     order: 11130,
-                    isOverlay: true,
                     isDefault: false,
                     layer: new StravaHeatmap('https://heatmap-external-{s}.strava.com/tiles-auth/all/hot/{z}/{x}/{y}.png?px=256',
-                        {code: 'Sa', scaleDependent: true, print: false, jnx: false, subdomains: 'abc',
-                         maxNativeZoom: 16, noCors: true}
+                        {
+                            code: 'Sa',
+                            isOverlay: true,
+                            scaleDependent: true,
+                            print: false,
+                            jnx: false,
+                            subdomains: 'abc',
+                            maxNativeZoom: 16,
+                            noCors: true
+                        }
                     )
                 },
                 {
                     title: 'Strava heatmap (run)',
-                    shortName: 'strava_run',
                     order: 11131,
-                    isOverlay: true,
                     isDefault: false,
                     layer: new StravaHeatmap('https://heatmap-external-{s}.strava.com/tiles-auth/run/hot/{z}/{x}/{y}.png?px=256',
-                        {code: 'Sr', scaleDependent: true, print: false, jnx: false, subdomains: 'abc',
-                         maxNativeZoom: 16, noCors: true}
+                        {
+                            code: 'Sr',
+                            isOverlay: true,
+                            scaleDependent: true,
+                            print: false,
+                            jnx: false,
+                            subdomains: 'abc',
+                            maxNativeZoom: 16,
+                            noCors: true
+                        }
                     )
                 },
                 {
                     title: 'Strava heatmap (ride)',
-                    shortName: 'strava_ride',
                     order: 11132,
-                    isOverlay: true,
                     isDefault: false,
                     layer: new StravaHeatmap('https://heatmap-external-{s}.strava.com/tiles-auth/ride/hot/{z}/{x}/{y}.png?px=256',
-                        {code: 'Sb', scaleDependent: true, print: false, jnx: false, subdomains: 'abc',
-                         maxNativeZoom: 16, noCors: true}
+                        {
+                            code: 'Sb',
+                            isOverlay: true,
+                            scaleDependent: true,
+                            print: false,
+                            jnx: false,
+                            subdomains: 'abc',
+                            maxNativeZoom: 16,
+                            noCors: true
+                        }
                     )
                 },
                 {
                     title: 'Strava heatmap (winter)',
-                    shortName: 'strava_winter',
                     order: 11133,
-                    isOverlay: true,
                     isDefault: false,
                     layer: new StravaHeatmap('https://heatmap-external-{s}.strava.com/tiles-auth/winter/hot/{z}/{x}/{y}.png?px=256',
-                        {code: 'Sw', scaleDependent: true, print: false, jnx: false, subdomains: 'abc',
-                         maxNativeZoom: 16, noCors: true}
+                        {
+                            code: 'Sw',
+                            isOverlay: true,
+                            scaleDependent: true,
+                            print: false,
+                            jnx: false,
+                            subdomains: 'abc',
+                            maxNativeZoom: 16,
+                            noCors: true
+                        }
                     )
                 },
                 {
                     title: 'Strava heatmap lowres (all)',
-                    shortName: 'strava_lowres',
                     order: 11134,
-                    isOverlay: true,
                     isDefault: false,
                     layer: L.tileLayer('https://heatmap-external-{s}.strava.com/tiles/all/hot/{z}/{x}/{y}.png?px=256',
-                        {code: 'Sal', scaleDependent: true, print: false, jnx: false, subdomains: 'abc',
-                         maxNativeZoom: 12, noCors: true}
+                        {
+                            code: 'Sal',
+                            isOverlay: true,
+                            scaleDependent: true,
+                            print: false,
+                            jnx: false,
+                            subdomains: 'abc',
+                            maxNativeZoom: 12,
+                            noCors: true
+                        }
                     )
                 },
                 {
                     title: 'Strava heatmap lowres (run)',
-                    shortName: 'strava_lowres_run',
                     order: 11135,
-                    isOverlay: true,
                     isDefault: false,
                     layer: L.tileLayer('https://heatmap-external-{s}.strava.com/tiles/run/hot/{z}/{x}/{y}.png?px=256',
-                        {code: 'Srl', scaleDependent: true, print: false, jnx: false, subdomains: 'abc',
-                         maxNativeZoom: 12, noCors: true}
+                        {
+                            code: 'Srl',
+                            isOverlay: true,
+                            scaleDependent: true,
+                            print: false,
+                            jnx: false,
+                            subdomains: 'abc',
+                            maxNativeZoom: 12,
+                            noCors: true
+                        }
                     )
                 },
                 {
                     title: 'Strava heatmap lowres (ride)',
-                    shortName: 'strava_lowres_ride',
                     order: 11136,
-                    isOverlay: true,
                     isDefault: false,
                     layer: L.tileLayer('https://heatmap-external-{s}.strava.com/tiles/ride/hot/{z}/{x}/{y}.png?px=256',
-                        {code: 'Sbl', scaleDependent: true, print: false, jnx: false, subdomains: 'abc',
-                         maxNativeZoom: 12, noCors: true}
+                        {
+                            code: 'Sbl',
+                            isOverlay: true,
+                            scaleDependent: true,
+                            print: false,
+                            jnx: false,
+                            subdomains: 'abc',
+                            maxNativeZoom: 12,
+                            noCors: true
+                        }
                     )
                 },
                 {
                     title: 'Strava heatmap lowres (winter)',
-                    shortName: 'strava_lowres_winter',
                     order: 11137,
-                    isOverlay: true,
                     isDefault: false,
                     layer: L.tileLayer('https://heatmap-external-{s}.strava.com/tiles/winter/hot/{z}/{x}/{y}.png?px=256',
-                        {code: 'Swl', scaleDependent: true, print: false, jnx: false, subdomains: 'abc',
-                         maxNativeZoom: 12, noCors: true}
+                        {
+                            code: 'Swl',
+                            isOverlay: true,
+                            scaleDependent: true,
+                            print: false,
+                            jnx: false,
+                            subdomains: 'abc',
+                            maxNativeZoom: 12,
+                            noCors: true
+                        }
                     )
                 },
             ]
@@ -533,64 +779,104 @@ export default function getLayers() {
                 {
                     // Вместо 404 отдают 500 для отсутствующих тайлов
                     title: 'Norway UT map',
-                    shortName: 'norway_ut',
                     order: 5000,
-                    isOverlay: false,
                     isDefault: false,
                     layer: L.tileLayer("https://tilesprod.ut.no/tilestache/ut_topo_light/{z}/{x}/{y}.jpg",
-                        {code: 'Nu', tms: false, maxNativeZoom: 16, print: true, jnx: true, scaleDependent: true, noCors: false}
+                        {
+                            code: 'Nu',
+                            tms: false,
+                            maxNativeZoom: 16,
+                            print: true,
+                            jnx: true,
+                            scaleDependent: true,
+                            noCors: false,
+                            shortName: 'norway_ut'
+                        }
                     )
                 },
                 {
                     title: 'Norway paper map',
-                    shortName: 'norway_paper',
                     order: 10310,
-                    isOverlay: true,
                     isDefault: false,
                     layer: new L.TileLayer.Nordeskart('https://gatekeeper1.geonorge.no/BaatGatekeeper/gk/gk.cache_gmaps?layers=toporaster3&zoom={z}&x={x}&y={y}&gkt={baatToken}',
-                        {code: 'Np', maxNativeZoom: 16, tms: false, print: true, jnx: true, scaleDependent: true}
+                        {
+                            code: 'Np',
+                            isOverlay: true,
+                            maxNativeZoom: 16,
+                            tms: false,
+                            print: true,
+                            jnx: true,
+                            scaleDependent: true,
+                            shortName: 'norway_paper'
+                        }
                     )
                 },
                 {
                     title: 'Norway map',
-                    shortName: 'norway',
                     order: 10320,
-                    isOverlay: true,
                     isDefault: false,
                     layer: new L.TileLayer.Nordeskart('https://gatekeeper1.geonorge.no/BaatGatekeeper/gk/gk.cache_gmaps?layers=topo4&zoom={z}&x={x}&y={y}&gkt={baatToken}',
-                        {code: 'Nm', tms: false, print: true, jnx: true, scaleDependent: true}
+                        {
+                            code: 'Nm',
+                            isOverlay: true,
+                            tms: false,
+                            print: true,
+                            jnx: true,
+                            scaleDependent: true,
+                            shortName: 'norway'
+                        }
                     )
                 },
                 {
                     title: 'Norway summer trails',
-                    shortName: 'norway_summer',
                     order: 20000,
-                    isOverlay: true,
                     isDefault: false,
                     layer: L.tileLayer("https://tilesprod.ut.no/tilestache/dnt_sommer/{z}/{x}/{y}.png",
-                        {code: 'Ns', tms: false, print: true, jnx: true, scaleDependent: true, noCors: false}
+                        {
+                            code: 'Ns',
+                            isOverlay: true,
+                            tms: false,
+                            print: true,
+                            jnx: true,
+                            scaleDependent: true,
+                            noCors: false,
+                            shortName: 'norway_summer'
+                        }
                     )
                 },
                 {
                     title: 'Norway winter trails',
-                    shortName: 'norway_winter',
                     order: 20010,
-                    isOverlay: true,
                     isDefault: false,
                     layer: L.tileLayer("https://tilesprod.ut.no/tilestache/dnt_vinter/{z}/{x}/{y}.png",
-                        {code: 'Nw', tms: false, print: true, jnx: true, scaleDependent: true, noCors: false}
+                        {
+                            code: 'Nw',
+                            isOverlay: true,
+                            tms: false,
+                            print: true,
+                            jnx: true,
+                            scaleDependent: true,
+                            noCors: false,
+                            shortName: 'norway_winter'
+                        }
                     )
                 },
                 {
                     // Вместо 404 отдают 500 для отсутствующих тайлов
                     title: 'Norway roads',
-                    shortName: 'norway_roads',
                     description: '<a href="https://kart.finn.no/">https://kart.finn.no/</a>',
                     order: 5030,
-                    isOverlay: false,
                     isDefault: false,
                     layer: L.tileLayer("https://maptiles1.finncdn.no/tileService/1.0.3/normap/{z}/{x}/{y}.png",
-                        {code: 'Nr', tms: false, print: true, jnx: true, scaleDependent: true, noCors: true}
+                        {
+                            code: 'Nr',
+                            tms: false,
+                            print: true,
+                            jnx: true,
+                            scaleDependent: true,
+                            noCors: true,
+                            shortName: 'norway_roads'
+                        }
                     )
                 }]
         },
@@ -599,52 +885,82 @@ export default function getLayers() {
             layers: [
                 {
                     title: 'Czech base',
-                    shortName: 'czech',
                     order: 5040,
-                    isOverlay: false,
                     isDefault: false,
                     layer: L.tileLayer("https://m{s}.mapserver.mapy.cz/base-m/{z}-{x}-{y}",
-                        {code: 'Czb', tms: false, print: true, jnx: true, subdomains: '1234', scaleDependent: true}
+                        {
+                            code: 'Czb',
+                            tms: false,
+                            print: true,
+                            jnx: true,
+                            subdomains: '1234',
+                            scaleDependent: true,
+                            shortName: 'czech'
+                        }
                     )
                 },
                 {
                     title: 'Czech tourist',
-                    shortName: 'czech_tourist',
                     order: 5050,
-                    isOverlay: false,
                     isDefault: false,
                     layer: L.tileLayer("https://m{s}.mapserver.mapy.cz/turist-m/{z}-{x}-{y}",
-                        {code: 'Czt', tms: false, print: true, jnx: true, subdomains: '1234', scaleDependent: true}
+                        {
+                            code: 'Czt',
+                            tms: false,
+                            print: true,
+                            jnx: true,
+                            subdomains: '1234',
+                            scaleDependent: true,
+                            shortName: 'czech_tourist'
+                        }
                     )
                 },
                 {
                     title: 'Czech summer',
-                    shortName: 'czech_summer',
                     order: 5060,
-                    isOverlay: false,
                     isDefault: false,
                     layer: L.tileLayer("https://m{s}.mapserver.mapy.cz/turist_aquatic-m/{z}-{x}-{y}",
-                        {code: 'Czs', tms: false, print: true, jnx: true, subdomains: '1234', scaleDependent: true}
+                        {
+                            code: 'Czs',
+                            tms: false,
+                            print: true,
+                            jnx: true,
+                            subdomains: '1234',
+                            scaleDependent: true,
+                            shortName: 'czech_summer'
+                        }
                     )
                 },
                 {
                     title: 'Czech winter',
-                    shortName: 'czech_winter',
                     order: 5070,
-                    isOverlay: false,
                     isDefault: false,
                     layer: L.tileLayer("https://m{s}.mapserver.mapy.cz/winter-m/{z}-{x}-{y}",
-                        {code: 'Czw', tms: false, print: true, jnx: true, subdomains: '1234', scaleDependent: true}
+                        {
+                            code: 'Czw',
+                            tms: false,
+                            print: true,
+                            jnx: true,
+                            subdomains: '1234',
+                            scaleDependent: true,
+                            shortName: 'czech_winter'
+                        }
                     )
                 },
                 {
                     title: 'Czech geographical',
-                    shortName: 'czech_geo',
                     order: 5080,
-                    isOverlay: false,
                     isDefault: false,
                     layer: L.tileLayer("https://m{s}.mapserver.mapy.cz/zemepis-m/{z}-{x}-{y}",
-                        {code: 'Czg', tms: false, print: true, jnx: true, subdomains: '1234', scaleDependent: true}
+                        {
+                            code: 'Czg',
+                            tms: false,
+                            print: true,
+                            jnx: true,
+                            subdomains: '1234',
+                            scaleDependent: true,
+                            shortName: 'czech_geo'
+                        }
                     )
                 }]
         }
@@ -655,10 +971,15 @@ export default function getLayers() {
     const shortNames = new Set();
     for (let group of layers) {
         for (let layer of group.layers) {
-            if (!layer.layer.options) {
+            const { layer: { options } } = layer
+            if (!options) {
                 throw new Error('Layer without options: ' + layer.title);
             }
-            let code = layer.layer.options.code;
+            const {
+                code,
+                shortName,
+                print
+            } = options
             if (!code) {
                 throw new Error('Layer without code: ' + layer.title);
             }
@@ -674,14 +995,16 @@ export default function getLayers() {
                 throw new Error(`Duplicate layer order "${order}"`);
             }
             orders[order] = 1;
-            let shortName = layer.shortName;
-            if (!shortName) {
-                throw new Error('Layer without shortName: ' + layer.title);
+
+            if (print) {
+              if (!shortName) {
+                  throw new Error('Layer without shortName: ' + layer.title);
+              }
+              if (shortNames.has(shortName)) {
+                  throw new Error(`Duplicate layer shortName "${shortName}"`);
+              }
+              shortNames.add(shortName);
             }
-            if (shortNames.has(shortName)) {
-                throw new Error(`Duplicate layer shortName "${shortName}"`);
-            }
-            shortNames.add(shortName);
         }
     }
     return layers;

--- a/src/layers.js
+++ b/src/layers.js
@@ -25,6 +25,7 @@ export default function getLayers() {
                     layer: L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
                         {
                             code: 'O',
+                            isOverlay: false,
                             scaleDependent: true,
                             print: true,
                             jnx: true,
@@ -40,6 +41,7 @@ export default function getLayers() {
                         'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
                         {
                             code: 'E',
+                            isOverlay: false,
                             scaleDependent: false,
                             maxNativeZoom: 18,
                             print: true,
@@ -56,6 +58,7 @@ export default function getLayers() {
                         {
                             scaleDependent: true,
                             code: 'Y',
+                            isOverlay: false,
                             print: true,
                             jnx: true,
                             shortName: 'yandex'
@@ -70,6 +73,7 @@ export default function getLayers() {
                         {
                             scaleDependent: false,
                             code: 'S',
+                            isOverlay: false,
                             print: true,
                             jnx: true,
                             shortName: 'yandex_sat'
@@ -83,6 +87,7 @@ export default function getLayers() {
                     layer: new L.Layer.Google('ROADMAP',
                         {
                             code: 'G',
+                            isOverlay: false,
                             scaleDependent: true,
                             print: true,
                             jnx: true,
@@ -97,6 +102,7 @@ export default function getLayers() {
                     layer: new L.Layer.Google('SATELLITE',
                         {
                             code: 'L',
+                            isOverlay: false,
                             scaleDependent: false,
                             print: true,
                             jnx: true,
@@ -111,6 +117,7 @@ export default function getLayers() {
                     layer: new L.Layer.Google('TERRAIN',
                         {
                             code: 'P',
+                            isOverlay: false,
                             scaleDependent: false,
                             print: true,
                             jnx: true,
@@ -125,10 +132,11 @@ export default function getLayers() {
                     layer: new BingLayer(config.bingKey,
                         {
                             code: 'I',
+                            isOverlay: false,
                             scaleDependent: false,
                             print: true,
                             jnx: true,
-                            shortName: 'bing'
+                            shortName: 'bing_sat'
                         }
                     )
                 },
@@ -140,6 +148,7 @@ export default function getLayers() {
                     layer: L.tileLayer('https://maps.marshruty.ru/ml.ashx?x={x}&y={y}&z={z}&i=1&al=1',
                         {
                             code: 'M',
+                            isOverlay: false,
                             maxNativeZoom: 18,
                             noCors: true,
                             scaleDependent: true,
@@ -157,6 +166,7 @@ export default function getLayers() {
                         'http://144.76.234.108/cgi-bin/tapp/tilecache.py/1.0.0/topomapper_v2/{z}/{x}/{y}.jpg',
                         {
                             code: 'T',
+                            isOverlay: false,
                             scaleDependent: false,
                             maxNativeZoom: 13,
                             noCors: true,
@@ -175,6 +185,7 @@ export default function getLayers() {
                         {
                             code: 'D',
                             isOverlay: true,
+                            isOverlayTransparent: false,
                             tms: true,
                             scaleDependent: false,
                             maxNativeZoom: 9,
@@ -192,6 +203,7 @@ export default function getLayers() {
                         {
                             code: 'N',
                             isOverlay: true,
+                            isOverlayTransparent: false,
                             tms: true,
                             scaleDependent: false,
                             maxNativeZoom: 12,
@@ -209,6 +221,7 @@ export default function getLayers() {
                         {
                             code: 'A',
                             isOverlay: true,
+                            isOverlayTransparent: false,
                             tms: true,
                             scaleDependent: false,
                             maxNativeZoom: 13,
@@ -226,6 +239,7 @@ export default function getLayers() {
                         {
                             code: 'Q',
                             isOverlay: true,
+                            isOverlayTransparent: false,
                             tms: true,
                             scaleDependent: false,
                             maxNativeZoom: 13,
@@ -243,6 +257,7 @@ export default function getLayers() {
                         {
                             code: 'J',
                             isOverlay: true,
+                            isOverlayTransparent: false,
                             tms: true,
                             scaleDependent: false,
                             maxNativeZoom: 13,
@@ -260,6 +275,7 @@ export default function getLayers() {
                         {
                             code: 'C',
                             isOverlay: true,
+                            isOverlayTransparent: false,
                             tms: true,
                             scaleDependent: false,
                             maxNativeZoom: 13,
@@ -277,6 +293,7 @@ export default function getLayers() {
                         {
                             code: 'F',
                             isOverlay: true,
+                            isOverlayTransparent: false,
                             tms: true,
                             scaleDependent: false,
                             maxNativeZoom: 14,
@@ -294,6 +311,7 @@ export default function getLayers() {
                         {
                             code: 'B',
                             isOverlay: true,
+                            isOverlayTransparent: false,
                             tms: true,
                             scaleDependent: false,
                             maxNativeZoom: 14,
@@ -311,6 +329,7 @@ export default function getLayers() {
                         {
                             code: 'K',
                             isOverlay: true,
+                            isOverlayTransparent: false,
                             tms: true,
                             scaleDependent: false,
                             maxNativeZoom: 15,
@@ -328,6 +347,7 @@ export default function getLayers() {
                         {
                             code: 'Z',
                             isOverlay: true,
+                            isOverlayTransparent: false,
                             tms: true,
                             scaleDependent: false,
                             maxNativeZoom: 14,
@@ -345,7 +365,7 @@ export default function getLayers() {
                         {
                             code: 'U',
                             isOverlay: true,
-                            isOverlayTransparent: true,
+                            isOverlayTransparent: false,
                             tms: true,
                             scaleDependent: false,
                             maxNativeZoom: 15,
@@ -363,7 +383,7 @@ export default function getLayers() {
                         {
                             code: 'R',
                             isOverlay: true,
-                            isOverlayTransparent: true,
+                            isOverlayTransparent: false,
                             tms: true,
                             scaleDependent: false,
                             maxNativeZoom: 17,
@@ -379,8 +399,7 @@ export default function getLayers() {
                     isDefault: true,
                     layer: new L.Layer.SovietTopoGrid({
                         code: 'Ng',
-                        isOverlay: true,
-                        shortName: 'soviet_topo_grid'
+                        isOverlay: true
                     })
                 },
                 {
@@ -389,8 +408,7 @@ export default function getLayers() {
                     isDefault: true,
                     layer: new L.Wikimapia({
                         code: 'W',
-                        isOverlay: true,
-                        shortName: 'wikimapia'
+                        isOverlay: true
                     })
                 },
                 {
@@ -403,7 +421,7 @@ export default function getLayers() {
                             isOverlayTransparent: true,
                             print: true,
                             scaleDependent: true,
-                            shortName: 'westra'
+                            shortName: 'passes'
                         }
                     )
                 },
@@ -432,6 +450,7 @@ export default function getLayers() {
                     layer: L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png',
                         {
                             code: 'Otm',
+                            isOverlay: false,
                             maxNativeZoom: 17,
                             scaleDependent: true,
                             print: true,
@@ -449,10 +468,11 @@ export default function getLayers() {
                     layer: L.tileLayer('https://{s}.tile.thunderforest.com/cycle/{z}/{x}/{y}.png?apikey=' + config.thunderforestKey,
                         {
                             code: 'Ocm',
+                            isOverlay: false,
                             scaleDependent: true,
                             print: true,
                             jnx: true,
-                            shortName: 'ocm'
+                            shortName: 'opencyclemap'
                         }
                     )
                 },
@@ -463,6 +483,7 @@ export default function getLayers() {
                     layer: L.tileLayer('https://{s}.tile.thunderforest.com/outdoors/{z}/{x}/{y}.png?apikey=' + config.thunderforestKey,
                         {
                             code: 'Oso',
+                            isOverlay: false,
                             scaleDependent: true,
                             print: true,
                             jnx: true,
@@ -484,6 +505,7 @@ export default function getLayers() {
                         {
                             code: 'E25m',
                             isOverlay: true,
+                            isOverlayTransparent: false,
                             tms: true,
                             maxNativeZoom: 9,
                             print: true,
@@ -501,6 +523,7 @@ export default function getLayers() {
                         {
                             code: 'NT1',
                             isOverlay: true,
+                            isOverlayTransparent: false,
                             tms: true,
                             maxNativeZoom: 14,
                             print: true,
@@ -518,6 +541,7 @@ export default function getLayers() {
                         {
                             code: 'NT5',
                             isOverlay: true,
+                            isOverlayTransparent: false,
                             tms: true,
                             maxNativeZoom: 15,
                             print: true,
@@ -535,6 +559,7 @@ export default function getLayers() {
                         {
                             code: 'T25',
                             isOverlay: true,
+                            isOverlayTransparent: false,
                             tms: true,
                             maxNativeZoom: 15,
                             print: true,
@@ -553,6 +578,7 @@ export default function getLayers() {
                         {
                             code: 'MN25',
                             isOverlay: true,
+                            isOverlayTransparent: false,
                             tms: true,
                             maxNativeZoom: 15,
                             print: true,
@@ -577,6 +603,7 @@ export default function getLayers() {
                         {
                             code: 'Mt',
                             isOverlay: true,
+                            isOverlayTransparent: false,
                             tms: false,
                             minZoom: 7,
                             minNativeZoom: 7,
@@ -614,6 +641,7 @@ export default function getLayers() {
                     layer: new GeocachingSu(config.geocachingSuUrl, {
                         code: 'Gc',
                         isOverlay: true,
+                        isOverlayTransparent: true,
                         print: true,
                         jnx: false,
                         shortName: 'geocaching'
@@ -627,6 +655,7 @@ export default function getLayers() {
                         {
                             code: 'Ot',
                             isOverlay: true,
+                            isOverlayTransparent: true,
                             scaleDependent: true,
                             print: true,
                             jnx: false,
@@ -784,6 +813,7 @@ export default function getLayers() {
                     layer: L.tileLayer("https://tilesprod.ut.no/tilestache/ut_topo_light/{z}/{x}/{y}.jpg",
                         {
                             code: 'Nu',
+                            isOverlay: false,
                             tms: false,
                             maxNativeZoom: 16,
                             print: true,
@@ -802,6 +832,7 @@ export default function getLayers() {
                         {
                             code: 'Np',
                             isOverlay: true,
+                            isOverlayTransparent: false,
                             maxNativeZoom: 16,
                             tms: false,
                             print: true,
@@ -819,6 +850,7 @@ export default function getLayers() {
                         {
                             code: 'Nm',
                             isOverlay: true,
+                            isOverlayTransparent: false,
                             tms: false,
                             print: true,
                             jnx: true,
@@ -835,6 +867,7 @@ export default function getLayers() {
                         {
                             code: 'Ns',
                             isOverlay: true,
+                            isOverlayTransparent: true,
                             tms: false,
                             print: true,
                             jnx: true,
@@ -852,6 +885,7 @@ export default function getLayers() {
                         {
                             code: 'Nw',
                             isOverlay: true,
+                            isOverlayTransparent: true,
                             tms: false,
                             print: true,
                             jnx: true,
@@ -870,6 +904,7 @@ export default function getLayers() {
                     layer: L.tileLayer("https://maptiles1.finncdn.no/tileService/1.0.3/normap/{z}/{x}/{y}.png",
                         {
                             code: 'Nr',
+                            isOverlay: false,
                             tms: false,
                             print: true,
                             jnx: true,
@@ -890,6 +925,7 @@ export default function getLayers() {
                     layer: L.tileLayer("https://m{s}.mapserver.mapy.cz/base-m/{z}-{x}-{y}",
                         {
                             code: 'Czb',
+                            isOverlay: false,
                             tms: false,
                             print: true,
                             jnx: true,
@@ -906,6 +942,7 @@ export default function getLayers() {
                     layer: L.tileLayer("https://m{s}.mapserver.mapy.cz/turist-m/{z}-{x}-{y}",
                         {
                             code: 'Czt',
+                            isOverlay: false,
                             tms: false,
                             print: true,
                             jnx: true,
@@ -922,6 +959,7 @@ export default function getLayers() {
                     layer: L.tileLayer("https://m{s}.mapserver.mapy.cz/turist_aquatic-m/{z}-{x}-{y}",
                         {
                             code: 'Czs',
+                            isOverlay: false,
                             tms: false,
                             print: true,
                             jnx: true,
@@ -938,6 +976,7 @@ export default function getLayers() {
                     layer: L.tileLayer("https://m{s}.mapserver.mapy.cz/winter-m/{z}-{x}-{y}",
                         {
                             code: 'Czw',
+                            isOverlay: false,
                             tms: false,
                             print: true,
                             jnx: true,
@@ -954,6 +993,7 @@ export default function getLayers() {
                     layer: L.tileLayer("https://m{s}.mapserver.mapy.cz/zemepis-m/{z}-{x}-{y}",
                         {
                             code: 'Czg',
+                            isOverlay: false,
                             tms: false,
                             print: true,
                             jnx: true,
@@ -978,7 +1018,9 @@ export default function getLayers() {
             const {
                 code,
                 shortName,
-                print
+                print,
+                isOverlay,
+                isOverlayTransparent
             } = options
             if (!code) {
                 throw new Error('Layer without code: ' + layer.title);
@@ -997,13 +1039,16 @@ export default function getLayers() {
             orders[order] = 1;
 
             if (print) {
-              if (!shortName) {
-                  throw new Error('Layer without shortName: ' + layer.title);
-              }
-              if (shortNames.has(shortName)) {
-                  throw new Error(`Duplicate layer shortName "${shortName}"`);
-              }
-              shortNames.add(shortName);
+                if (isOverlay && (isOverlayTransparent === undefined)) {
+                    throw new Error('Overlay layer without isOverlayTransparent: ' + layer.title);
+                }
+                if (!shortName) {
+                    throw new Error('Layer without shortName: ' + layer.title);
+                }
+                if (shortNames.has(shortName)) {
+                    throw new Error(`Duplicate layer shortName "${shortName}"`);
+                }
+                shortNames.add(shortName);
             }
         }
     }

--- a/src/layers.js
+++ b/src/layers.js
@@ -420,6 +420,8 @@ export default function getLayers() {
                         print: true,
                         scaleDependent: true,
                         isOverlay: true,
+                        isOverlayTransparent: true,
+                        shortName: 'passes',
                         markersOptions: {
                             isOverlay: true,
                             isOverlayTransparent: true,

--- a/src/layers.js
+++ b/src/layers.js
@@ -416,14 +416,16 @@ export default function getLayers() {
                     order: 11400,
                     isDefault: true,
                     layer: new L.Layer.WestraPasses(config.westraDataBaseUrl, {
-                            code: 'Wp',
+                        code: 'Wp',
+                        print: true,
+                        scaleDependent: true,
+                        isOverlay: true,
+                        markersOptions: {
                             isOverlay: true,
                             isOverlayTransparent: true,
-                            print: true,
-                            scaleDependent: true,
                             shortName: 'passes'
                         }
-                    )
+                    })
                 },
                 // {
                 //     title: 'Tracks',

--- a/src/lib/leaflet.control.layers.configure/index.js
+++ b/src/lib/leaflet.control.layers.configure/index.js
@@ -178,6 +178,7 @@ function enableConfig(control, layers) {
                         url: '',
                         tms: false,
                         maxZoom: 18,
+                        isOverlay: false,
                         scaleDependent: false
                     }
                 );

--- a/src/lib/leaflet.control.layers.configure/index.js
+++ b/src/lib/leaflet.control.layers.configure/index.js
@@ -178,7 +178,6 @@ function enableConfig(control, layers) {
                         url: '',
                         tms: false,
                         maxZoom: 18,
-                        isOverlay: false,
                         scaleDependent: false
                     }
                 );
@@ -194,8 +193,9 @@ function enableConfig(control, layers) {
                 enabledLayers.sort((l1, l2) => l1.order - l2.order);
                 enabledLayers.forEach((l) => {
                         l.layer._justAdded = addedLayers && addedLayers.includes(l);
-                        l.isOverlay ? this.addOverlay(l.layer, l.title) : this.addBaseLayer(l.layer, l.title);
-                        if (!l.isOverlay && this._map.hasLayer(l.layer)) {
+                        const { layer: { options: { isOverlay } } } = l
+                        isOverlay ? this.addOverlay(l.layer, l.title) : this.addBaseLayer(l.layer, l.title);
+                        if (!isOverlay && this._map.hasLayer(l.layer)) {
                               hasBaselayerOnMap = true;
                         }
                     }
@@ -203,7 +203,7 @@ function enableConfig(control, layers) {
                 // если нет активного базового слоя, включить первый, если он есть
                 if (!hasBaselayerOnMap) {
                     for (let layer of enabledLayers) {
-                        if (!layer.isOverlay) {
+                        if (!layer.layer.options.isOverlay) {
                             this._map.addLayer(layer.layer);
                             break;
                         }
@@ -395,6 +395,7 @@ ${buttonsHtml}`;
             createCustomLayer: function(fieldValues) {
                 const serialized = this.serializeCustomLayer(fieldValues);
                 const tileLayer = L.tileLayer(fieldValues.url, {
+                        isOverlay: fieldValues.isOverlay,
                         tms: fieldValues.tms,
                         maxNativeZoom: fieldValues.maxZoom,
                         scaleDependent: fieldValues.scaleDependent,
@@ -407,7 +408,6 @@ ${buttonsHtml}`;
 
                 const customLayer = {
                     title: fieldValues.name,
-                    isOverlay: fieldValues.isOverlay,
                     isDefault: false,
                     isCustom: true,
                     serialized: serialized,
@@ -464,7 +464,7 @@ ${buttonsHtml}`;
 
                 const newLayer = this.createCustomLayer(newFieldValues);
                 this._customLayers.splice(layerPos, 0, newLayer);
-                if (this._map.hasLayer(layer.layer) && (!layer.isOverlay || newLayer.isOverlay)) {
+                if (this._map.hasLayer(layer.layer) && (!layer.layer.options.isOverlay || newLayer.layer.options.isOverlay)) {
                     this._map.addLayer(newLayer.layer);
                 }
                 this._map.removeLayer(layer.layer);

--- a/src/lib/leaflet.control.printPages/control.js
+++ b/src/lib/leaflet.control.printPages/control.js
@@ -488,8 +488,7 @@ L.Control.PrintPages = L.Control.extend({
         getFileName: function({renderedLayers, scale, width, height, extension}) {
             let fileName = '';
 
-            let baseLayer;
-            let overlayLayer;
+            let opaqueLayer;
             const transparentOverlayLayers = [];
 
             renderedLayers.forEach(layer => {
@@ -509,20 +508,18 @@ L.Control.PrintPages = L.Control.extend({
                     if (isOverlayTransparent) {
                         transparentOverlayLayers.push(layer);
                     } else {
-                        overlayLayer = layer;
+                        opaqueLayer = layer;
                     }
-                } else {
-                    baseLayer = layer;
+                } else if (!opaqueLayer) {
+                    opaqueLayer = layer;
                 }
             });
 
             const appendLayerShortName = (layer) => {
                 fileName += `${layer.options.shortName}_`;
             }
-            if (overlayLayer) {
-                appendLayerShortName(overlayLayer);
-            } else if (baseLayer) {
-                appendLayerShortName(baseLayer);
+            if (opaqueLayer) {
+                appendLayerShortName(opaqueLayer);
             }
             transparentOverlayLayers.forEach(appendLayerShortName);
 

--- a/src/lib/leaflet.control.printPages/map-render.js
+++ b/src/lib/leaflet.control.printPages/map-render.js
@@ -185,7 +185,6 @@ async function* iterateLayersTiles(layers, latLngBounds, destPixelSize, resoluti
     };
     let doStop;
     for (let layer of layers) {
-        const layerCode = layer.options && layer.options.code;
         let zoom;
         if (layer.options && layer.options.scaleDependent) {
             zoom = zooms.mapZoom;
@@ -218,7 +217,7 @@ async function* iterateLayersTiles(layers, latLngBounds, destPixelSize, resoluti
             layerPromises.push(tilePromise.tilePromise);
             let progressInc = (layer._printProgressWeight || 1) / count;
             tilePromise.tilePromise =
-                tilePromise.tilePromise.then((tileInfo) => Object.assign({zoom, progressInc, layerCode}, tileInfo));
+                tilePromise.tilePromise.then((tileInfo) => Object.assign({zoom, progressInc, layer}, tileInfo));
             doStop = yield tilePromise;
             if (doStop) {
                 tilePromise.abortLoading();
@@ -277,7 +276,7 @@ async function renderPages({map, pages, zooms, resolution, scale, progressCallba
     }
     progressRange *= pages.length;
     const pageImagesInfo = [];
-    const renderedLayerCodes = new Set();
+    const renderedLayers = new Set();
     for (let page of pages) {
         let destPixelSize = page.printSize.multiplyBy(resolution / 25.4).round();
         let pixelBounds = L.bounds(
@@ -304,7 +303,7 @@ async function renderPages({map, pages, zooms, resolution, scale, progressCallba
             progressCallback(tileInfo.progressInc, progressRange);
             composer.putTile(tileInfo);
             if (tileInfo.image) {
-                renderedLayerCodes.add(tileInfo.layerCode);
+                renderedLayers.add(tileInfo.layer);
             }
         }
         const dataUrl = composer.getDataUrl();
@@ -317,7 +316,7 @@ async function renderPages({map, pages, zooms, resolution, scale, progressCallba
             }
         );
     }
-    return { images: pageImagesInfo, renderedLayerCodes };
+    return { images: pageImagesInfo, renderedLayers };
 }
 
 

--- a/src/lib/leaflet.control.printPages/map-render.js
+++ b/src/lib/leaflet.control.printPages/map-render.js
@@ -312,7 +312,7 @@ async function renderPages({map, pages, zooms, resolution, scale, progressCallba
             }
         );
     }
-    return pageImagesInfo;
+    return { images: pageImagesInfo, layers };
 }
 
 

--- a/src/lib/leaflet.control.printPages/map-render.js
+++ b/src/lib/leaflet.control.printPages/map-render.js
@@ -302,8 +302,9 @@ async function renderPages({map, pages, zooms, resolution, scale, progressCallba
             }
             progressCallback(tileInfo.progressInc, progressRange);
             composer.putTile(tileInfo);
-            if (tileInfo.image) {
-                renderedLayers.add(tileInfo.layer);
+            const {image, draw, layer} = tileInfo;
+            if ((image || draw) && !layer._layerDummy) {
+                renderedLayers.add(layer);
             }
         }
         const dataUrl = composer.getDataUrl();
@@ -316,7 +317,7 @@ async function renderPages({map, pages, zooms, resolution, scale, progressCallba
             }
         );
     }
-    return { images: pageImagesInfo, renderedLayers };
+    return {images: pageImagesInfo, renderedLayers};
 }
 
 

--- a/src/lib/leaflet.layer.rasterize/WestraPasses.js
+++ b/src/lib/leaflet.layer.rasterize/WestraPasses.js
@@ -20,7 +20,7 @@ WestraPassesMarkers.include({
     },
 
     cloneForPrint: function (options) {
-        options = L.Util.extend({}, options);
+        options = L.Util.extend({}, this.options, options);
         return new WestraPassesMarkers(this._baseUrl, options);
     },
 

--- a/src/lib/leaflet.layer.westraPasses/index.js
+++ b/src/lib/leaflet.layer.westraPasses/index.js
@@ -12,7 +12,7 @@ L.Layer.WestraPasses = L.Layer.extend({
 
         initialize: function(baseUrl, options) {
             L.setOptions(this, options);
-            this.markers = new WestraPassesMarkers(baseUrl);
+            this.markers = new WestraPassesMarkers(baseUrl, options.markersOptions);
             this.regions1 = new L.Layer.GeoJSONAjax(baseUrl + this.options.fileRegions1, {
                     className: 'westra-region-polygon',
                     onEachFeature: this._setRegionLabel.bind(this, 'regions1')


### PR DESCRIPTION
фикс для #43 

В качестве имен слоев использовал `options.code`, не уверен что это хорошая идея. Возможно лучше будет добавить каждому слою новую опцию? Например для OSM будет так:

`{code: 'O', scaleDependent: true, print: true, jnx: true, fileName: 'osm'}`