### PR TITLE
[tracks] load tracks from gpslib url

### DIFF
--- a/src/lib/leaflet.control.track-list/lib/geo_file_formats.js
+++ b/src/lib/leaflet.control.track-list/lib/geo_file_formats.js
@@ -6,6 +6,7 @@ import {decode as utf8_decode} from 'utf8';
 import {fetch} from 'lib/xhr-promise';
 import urlViaCorsProxy from 'lib/CORSProxy';
 import {isGpsiesUrl, gpsiesRequestOptions, gpsiesParser} from './gpsies';
+import {isGpslibUrl, gpslibRequestOptions, gpslibParser} from './gpslib';
 import {isStravaUrl, stravaRequestOptions, stravaParser} from './strava';
 import {isEndomondoUrl, endomondoRequestOptions, endomondoParser} from './endomondo';
 import {parseTrackUrlData, parseNakarteUrl, isNakarteLinkUrl, nakarteLinkRequestOptions, nakarteLinkParser} from './nktk';
@@ -623,6 +624,9 @@ async function loadFromUrl(url) {
     if (isGpsiesUrl(url)) {
         requestOptionsGetter = gpsiesRequestOptions;
         parser = gpsiesParser;
+    } else if (isGpslibUrl(url)) {
+        requestOptionsGetter = gpslibRequestOptions;
+        parser = gpslibParser;
     } else if (isEndomondoUrl(url)) {
         requestOptionsGetter = endomondoRequestOptions;
         parser = endomondoParser;

--- a/src/lib/leaflet.control.track-list/lib/gpslib.js
+++ b/src/lib/leaflet.control.track-list/lib/gpslib.js
@@ -1,0 +1,31 @@
+import urlViaCorsProxy from 'lib/CORSProxy';
+import {parseGpx} from './geo_file_formats'
+
+const re = /^https?:\/\/(?:.*\.)?gpslib\.[^.]+\/tracks\/info\/(\d+)/;
+
+function isGpslibUrl(url) {
+    return re.test(url);
+}
+
+function gpslibRequestOptions(url) {
+    const m = re.exec(url);
+    if (!m) {
+        throw new Error('Invalid gpslib url');
+    }
+    const trackId = m[1];
+    const requestOptions = [
+        {
+            url: urlViaCorsProxy(`https://www.gpslib.ru/tracks/download/${trackId}.gpx`),
+            options: {responseType: 'binarystring'}
+        }];
+    return {requestOptions};
+}
+
+function gpslibParser(name, responses) {
+    if (responses.length !== 1) {
+        throw new Error(`Invalid responses array length ${responses.length}`);
+    }
+    return parseGpx(responses[0].responseBinaryText, name, true);
+}
+
+export {gpslibRequestOptions, isGpslibUrl, gpslibParser}

--- a/src/lib/leaflet.control.track-list/track-list.js
+++ b/src/lib/leaflet.control.track-list/track-list.js
@@ -71,7 +71,7 @@ L.Control.TrackList = L.Control.extend({
                 <div class="leaflet-control-content">
                 <div class="header">
                     <div class="hint">
-                        gpx kml Ozi zip YandexMaps GPSies Strava endomondo
+                        gpx kml Ozi zip YandexMaps GPSies GPSLib Strava endomondo
                     </div>
                     <div class="button-minimize" data-bind="click: setMinimized"></div>
                 </div>


### PR DESCRIPTION
[GPSLib](https://www.gpslib.ru/) - Хостинг GPS треков.

Примеры валидных ссылок:

- https://www.gpslib.ru/tracks/info/70473.html
- https://www.gpslib.ru/tracks/info/70473
- https://www.gpslib.net/tracks/info/70473.html
- https://fi.gpslib.net/tracks/info/70473.html

Строка подсказки (`gpx kml Ozi zip YandexMaps GPSies GPSLib Strava endomondo`) становится уже слишком длинной, можно например сделать чтобы только по нажатию на значек подсказки показывать весь список поддерживаемых сервисов/ссылок.

Мониторинг #170.