### PR TITLE
Added layer osmpasses to display passes via overpassTurbo, see #214

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -11,5 +11,6 @@ export default Object.assign({
     elevationsServer: 'https://elevation.nakarte.me/',
     wikimediaCommonsCoverageUrl: 'https://tiles.nakarte.me/wikimedia_commons_images/{z}/{x}/{y}',
     geocachingSuUrl: 'https://nakarte.me/geocachingSu/geocaching_su2.json',
+    overpassTurboUrl: 'https://overpass.kumi.systems/api/interpreter',
     tracksStorageServer: 'https://tracks.nakarte.me',
 }, secrets);

--- a/src/layers.js
+++ b/src/layers.js
@@ -9,6 +9,7 @@ import 'lib/leaflet.layer.westraPasses';
 import 'lib/leaflet.layer.nordeskart';
 import 'lib/leaflet.layer.wikimapia';
 import {GeocachingSu} from 'lib/leaflet.layer.geocaching-su';
+import {OSMPasses} from 'lib/leaflet.layer.osmpasses';
 import {StravaHeatmap} from 'lib/leaflet.layer.strava-heatmap';
 
 export default function getLayers() {
@@ -578,6 +579,18 @@ export default function getLayers() {
                     })
                 },
                 {
+                    title: 'OSM passes',
+                    isDefault: false,
+                    layer: new OSMPasses(config.overpassTurboUrl, {
+                        code: 'OP',
+                        isOverlay: true,
+                        isOverlayTransparent: true,
+                        print: true,
+                        jnx: false,
+                        shortName: 'osmpasses'
+                    })
+                },
+                {
                     title: 'OpenStreetMap GPS traces',
                     isDefault: false,
                     layer: L.tileLayer('https://{s}.gps-tile.openstreetmap.org/lines/{z}/{x}/{y}.png',
@@ -1047,7 +1060,9 @@ export default function getLayers() {
             layers: [
                 'Mountains by Aleksey Tsvetkov',
                 'Bing imagery acquisition dates',
-                'geocaching.su']
+                'geocaching.su',
+                'OSM passes',
+            ]
         },
         {
             title: 'Routes and traces',
@@ -1162,6 +1177,7 @@ export default function getLayers() {
         // point overlays
         'Mountain passes (Westra)',
         'geocaching.su',
+        'OSM passes',
     ];
 
     // set metadata

--- a/src/lib/leaflet.layer.osmpasses/index.js
+++ b/src/lib/leaflet.layer.osmpasses/index.js
@@ -1,0 +1,189 @@
+import L from 'leaflet';
+import {fetch} from 'lib/xhr-promise';
+import 'lib/leaflet.layer.canvasMarkers';
+import logging from 'lib/logging';
+import {notify} from 'lib/notifications';
+import iconFromBackgroundImage from 'lib/iconFromBackgroundImage';
+
+// Possible Improvements:
+// - tooltips
+// - means to download GPX/KML of a pass
+
+const OSMPasses = L.Layer.CanvasMarkers.extend({
+    options: {
+        minZoom: 10, // to be kind on the overpassTurbo guys
+        scaleDependent: true,
+		attribution: "© OpenStreetMap",
+    },
+
+    _query: "data=%5Bout%3Ajson%5D%5Btimeout%3A25%5D%3B%0A%28node%5B%22mountain_pass%22%5D%28{bbox}%29%3B%29%3B%0Aout%20body%3B%0A%3E%3B%0Aout%20skel%20qt%3B",
+
+    // initialize: API hook from Layer
+    // `url` is given in the Layer constructor
+    // and it is a choice of a suitable overpassTurbo server
+    initialize: function(url, options) {
+        this.dataUrl = url;
+        L.Layer.CanvasMarkers.prototype.initialize.call(this, null, options);
+    },
+
+    // drawTile: API hook from GridLayer called upon tile creation
+    // we intercept the hook and load passes within the tile
+    // before passing the control back to CanvasMarkers
+    // FIXME: this actually results in ugly blinks when loading the passes
+    drawTile: async function(canvas, coords) {
+        const
+            bounds = this._tileBounds(coords),
+            url = this._queryUrl(bounds);
+        if (!this._seenTile(coords)) {
+            await this._memoized((url) => this._loadData(url), url, "_loadDataUrls")
+        }
+        return L.Layer.CanvasMarkers.prototype.drawTile.call(this, canvas, coords);
+    },
+
+    // _tileBounds: convert tile `coords` to lat/lon `L.latLngBounds`
+    // FIXME: this function is probably already implemented in GridLayer
+    _tileBounds: function(coords) {
+        const
+            zoom = coords.z,
+            tileSize = this.options.tileSize,
+            tileN = coords.y * tileSize,
+            tileW = coords.x * tileSize,
+            tileS = tileN + tileSize,
+            tileE = tileW + tileSize;
+        return L.latLngBounds(
+            this._map.unproject(L.point(tileW, tileS), zoom),
+            this._map.unproject(L.point(tileE, tileN), zoom)
+        );
+    },
+
+    // _queryUrl: given `bounds` in lat/lon coordinates, generate
+    // an overpassTurbo query URL from template
+    _queryUrl: function(bounds) {
+        const
+            bbox = L.Util.template('{south},{west},{north},{east}', {
+                west: bounds.getWest(),
+                east: bounds.getEast(),
+                north: bounds.getNorth(),
+                south: bounds.getSouth(),
+            }),
+            query = L.Util.template(this._query, { bbox: bbox });
+        return this.dataUrl + '?' + query;
+    },
+
+    // _loadData: Load, parse and add markers from a given URL
+    // FIXME: the function sees too dumb, consider merging with another
+    _loadData: async function(url) {
+        return fetch(url, {responseType: 'json'})
+            .then(response => this._loadMarkers(response.response))
+            .catch(e => this._downloadError(e, url));
+    },
+
+    // Log download error and present it to the User
+    _downloadError: function(e, url) {
+        if (e) {
+            logging.captureException(e, {
+                    extra: {
+                        description: 'Failed to get OSM passes',
+                        url: url,
+                        status: e.xhr && e.xhr.status
+                    }
+                }
+            )
+        }
+        notify('Failed to get OSM passes data');
+    },
+
+    // _notSimultaneously: run asynchronous `fun`ction of no arguments
+    // unless function was already started (and not finished)
+    // with the same `semaphore` value
+    _notSimultaneously: function(fun, semaphore) {
+        const _this = this;
+        if (!_this[semaphore]) {
+            _this[semaphore] = true;
+            return fun()
+                .finally(() => { _this[semaphore] = false; });
+        }
+    },
+
+    // _memoized: run a `fun`ction of one `arg` with memoization:
+    // do not rerun it if it was called already
+    // cached function replies are stored in `this[storage]`
+    _memoized: function(fun, arg, storage) {
+        this[storage] = this[storage] || {}
+        if (typeof this[storage][arg] === "undefined") {
+            this[storage][arg] = fun(arg);
+        }
+        return this[storage][arg]
+    },
+
+    // _loadMarkers: convert response data to markers and load them
+    _loadMarkers: function(data) {
+        const fixScale = scale =>
+            (scale || "")
+                .toLowerCase()
+                .replace(/а/, "a").replace(/б/, "b")
+                .replace(/н.?к/, "nograde")
+                .match(/([1-3][ab]|nograde)?/)[0]
+                || "unknown";
+        const getIcon = scale =>
+            iconFromBackgroundImage('westra-pass-marker-' + fixScale(scale));
+
+        const markers = data.elements
+            .map(item => ({
+                latlng: {lat: item.lat, lng: item.lon},
+                label: item.tags.name,
+                icon: getIcon(item.tags.rtsa_scale),
+                id: item.id
+            }))
+        this.addMarkers(this._removeKnownMarkers(markers));
+    },
+
+    // _removeKnownMarkers: given a list of markers with id attribute,
+    // return a list with only markers not given to _removeKnownMarkers earlier
+    _known_markers: [],
+    _removeKnownMarkers: function(markers){
+        return markers
+            .filter(item => {
+                const seen = this._known_markers[item.id];
+                this._known_markers[item.id] = true;
+                return !seen
+            });
+    },
+
+    // Unfortunately, GridLayer does not expose a way to get child/parent tiles
+    // The code below is reverse-engineered from GridLayer._retainParent and co
+    // It works but depends on the internals of Leaflet...
+    // Presently, _parentTile is not used, but left here for the documentation purposes
+
+    // _parentTile: return coordinates of the z-1 level tile containing the given one
+    _parentTile: function(coords) {
+        const
+            x = Math.floor(coords.x / 2),
+            y = Math.floor(coords.y / 2);
+        var parentTile = L.Point(+x, +y);
+        parentTile.z = +coords.z - 1;
+        return parentTile;
+    },
+
+    // _seenTile: return true if a tile was covered by a previous download
+    // subsequent calls with the same tile or it's children will return false
+    _seenTileZ: {},
+    _seenTile: function(coords) {
+        for (var anti_z of Array(coords.z).keys()) {
+            // This could've used this._parentTile but the code would look uglier
+            const x = Math.floor(coords.x / 2 ** anti_z);
+            const y = Math.floor(coords.y / 2 ** anti_z);
+            const z = coords.z - anti_z;
+            const center = [x, y]
+            if (this._seenTileZ[center] <= z) {
+                return true;
+            }
+        }
+        const center = [coords.x, coords.y]
+        this._seenTileZ[center] = coords.z
+        return false;
+    }
+});
+
+
+export {OSMPasses}


### PR DESCRIPTION
Добавил слой osmpasses. Протестировал на несвежих десктопных Chrome и Firefox.

Здесь не работает подход, принятый у других польователей `canvasMarkers` с тем, чтобы загрузить сразу все метки один раз: даже запрос на весь Китай работает очень долго. Поэтому я делаю запрос на каждый tile и встраиваюсь в drawTile. Из-за этого получаются подмигивания (т.к. загрузка свежих данных сама по себе триггерит перерисовку).