### PR TITLE
config: speedup build by skipping some stepps for mapillary package

### DIFF
--- a/src/lib/leaflet.control.panoramas/lib/mapillary/index.js
+++ b/src/lib/leaflet.control.panoramas/lib/mapillary/index.js
@@ -11,9 +11,9 @@ function getCoverageLayer(options) {
 
 function getMapillary() {
     return new Promise((resolve) => {
-        require.ensure(['mapillary-js/dist/mapillary.js', 'mapillary-js/dist/mapillary.min.css'], () => {
+        require.ensure(['mapillary-js/dist/mapillary.min.js', 'mapillary-js/dist/mapillary.min.css'], () => {
             require('mapillary-js/dist/mapillary.min.css');
-            resolve(require('mapillary-js/dist/mapillary.js'));
+            resolve(require('mapillary-js/dist/mapillary.min.js'));
         }, 'mapillary');
     });
 }

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -4,6 +4,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const StyleLintPlugin = require('stylelint-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 
 const paths = require('./paths');
 
@@ -53,6 +54,14 @@ const babelConfig = {
     ]
 };
 
+const sourceMapOption = {
+    filename: '[file].map',
+    columns: isProduction,
+    exclude: /mapillary/
+};
+
+const devToolPlugin = isProduction ? Webpack.SourceMapDevToolPlugin : Webpack.EvalSourceMapDevToolPlugin;
+
 const plugins = [
     ...(isProduction ? [new CleanWebpackPlugin()] : []),
     ...(isProduction ? [new CopyWebpackPlugin([
@@ -77,7 +86,8 @@ const plugins = [
         ],
         emitWarning: isDevelopment,
         emitError: isProduction
-    })] : []
+    })] : [],
+    new devToolPlugin(sourceMapOption),
 ];
 
 const productionCSSLoader = [
@@ -154,7 +164,7 @@ const loaders = [
 
 module.exports = {
     mode: isProduction ? 'production' : 'development',
-    devtool: isProduction ? 'source-map' : 'cheap-eval-source-map',
+    devtool: false,
     stats: 'errors-warnings',
     bail: isProduction || isTesting,
 
@@ -168,6 +178,13 @@ module.exports = {
             name: true
         },
         runtimeChunk: 'single',
+        minimizer: [new TerserPlugin({
+            cache: true,
+            parallel: true,
+            sourceMap: true,
+            exclude: /mapillary/
+        })],
+
     },
 
     resolve: {


### PR DESCRIPTION
* replace devtool option whith explicit definition of source map plugin.
  This allows to configure it to excldue mapillary from processing
* require minimized version of mapillary package so that we can skip
  minification during build
* specify config for TerserPlugin to skip minification of mapillary chunk

This drastically reduces build time (minification 20 sec -> 5 sec,
source maps generation 88 sec -> sec) but increases mapillary chunk
gzipped size by 13 Kb/3.7%  (351 Kb -> 364 Kb)