### PR TITLE
strava heatmap: do automatic second stage login

### DIFF
--- a/src/lib/leaflet.layer.strava-heatmap/index.js
+++ b/src/lib/leaflet.layer.strava-heatmap/index.js
@@ -1,27 +1,13 @@
 import L from 'leaflet';
 import {notify} from '~/lib/notifications';
+import {fetch} from '~/lib/xhr-promise';
 
 const StravaHeatmap = L.TileLayer.extend({
+    options: {
+        authRenewInterval: 24 * 3600 * 1000,
+    },
 
-    _checkUserLoggedIn: function() {
-        const message = `
-            Для просмотра тепловой карты треков необходимо зарегистрироваться и залогиниться на сайте
-            <a title="Откроется в новом окне" target="_blank" href="https://strava.com/login">
-                https://strava.com/login</a>,
-            затем открыть карту на оригинальном сайте
-            <a title="Откроется в новом окне" target="_blank" href="https://www.strava.com/heatmap">
-                https://www.strava.com/heatmap</a>,
-            после чего перезагрузить эту страницу.<br>
-            Если вы не хотите регистририваться в сервисе Strava, вы можете выбрать в настройках слои с низким 
-            разрешением "Strava&nbsp;heatmap&nbsp;lowres", они доступны всем пользователям.<br><br>
-
-            You have to login at
-            <a title="Will open in new window" target="_blank" href="https://strava.com/login">
-                https://strava.com/login</a>
-            and then open <a title="Will open in new window" target="_blank" href="https://www.strava.com/heatmap">
-            https://www.strava.com/heatmap</a> to be able to view tracks heatmap.
-            Alternatively you can select low resolution layers in layers settings.`;
-
+    checkUserLoggedIn: async function() {
         const data = {
             x: 4954,
             y: 2559,
@@ -30,27 +16,63 @@ const StravaHeatmap = L.TileLayer.extend({
         };
         const url = L.Util.template(this._url, data);
         const image = new Image();
+        return new Promise((resolve) => {
+            image.onerror = () => resolve(false);
+            image.onload = () => resolve(true);
+            image.src = url;
+        });
+    },
 
-        image.onload = function() {
-            StravaHeatmap._loginChecked = true;
-        };
+    tryHeatmapLogin: async function() {
+        try {
+            await fetch('https://heatmap-external-a.strava.com/auth', {
+                withCredentials: true,
+                maxTries: 1,
+            });
+        } catch (e) {
+            // skip error
+        }
+    },
 
-        image.onerror = function() {
-            if (!StravaHeatmap._loginChecked) {
-                StravaHeatmap._loginChecked = true;
-                notify(message);
+    ensureUserLoggedIn: async function(showInstructions = true) {
+        if (!(await this.checkUserLoggedIn())) {
+            await this.tryHeatmapLogin();
+            this.redraw();
+            if (!(await this.checkUserLoggedIn())) {
+                if (this._map && showInstructions) {
+                    this.notifyUserNeedsLogin();
+                }
             }
-        };
+        }
+    },
 
-        image.src = url;
+    notifyUserNeedsLogin: function() {
+        const message = `
+                Для просмотра тепловой карты треков необходимо зарегистрироваться и залогиниться на сайте
+                <a title="Откроется в новом окне" target="_blank" href="https://strava.com/login">
+                    https://strava.com/login</a>, после чего нажать кнопку "Ok"<br>
+                Если вы не хотите регистририваться в сервисе Strava, вы можете выбрать в настройках слои с низким
+                разрешением "Strava&nbsp;heatmap&nbsp;lowres", они доступны всем пользователям.<br><br>
+
+                To use tracks heatmap you need to register and  log in at
+                <a title="Will open in new window" target="_blank" href="https://strava.com/login">
+                    https://strava.com/login</a>
+                and press "Ok" button afterwards.
+                If you do not want to register at Strava you can select low resolution maps in layers settings.`;
+
+        notify(message, () => this.ensureUserLoggedIn(false));
     },
 
     onAdd: function(map) {
         L.TileLayer.prototype.onAdd.call(this, map);
-        if (!StravaHeatmap._loginChecked) {
-            this._checkUserLoggedIn();
-        }
-    }
+        this.ensureUserLoggedIn();
+        this._authRenewIntervalId = setInterval(() => this.tryHeatmapLogin(), this.options.authRenewInterval);
+    },
+
+    onRemove: function(map) {
+        clearInterval(this._authRenewIntervalId);
+        L.TileLayer.prototype.onRemove.call(this, map);
+    },
 });
 
 export {StravaHeatmap};

--- a/src/lib/notifications/index.js
+++ b/src/lib/notifications/index.js
@@ -1,8 +1,8 @@
 import alertify from 'alertify.js';
 import './style.css';
 
-function notify(message) {
-    alertify.alert(message);
+function notify(message, onOk) {
+    alertify.alert(message, onOk);
 }
 
 function prompt(message, value) {

--- a/src/lib/xhr-promise/index.js
+++ b/src/lib/xhr-promise/index.js
@@ -22,7 +22,7 @@ class XMLHttpRequestPromise {
     constructor(
         url, {method = 'GET', data = null, responseType = '', timeout = 30000, maxTries = 3, retryTimeWait = 500,
             isResponseSuccess = successIfStatus200, responseNeedsRetry = retryIfNetworkErrorOrServerError,
-        headers = null} = {}) {
+            headers = null, withCredentials = false} = {}) {
         // console.log('promise constructor', url);
         const promise = new Promise((resolve, reject) => {
                 this._resolve = resolve;
@@ -54,6 +54,7 @@ class XMLHttpRequestPromise {
                 xhr.setRequestHeader(k, v);
             }
         }
+        xhr.withCredentials = withCredentials;
     }
 
     _open() {


### PR DESCRIPTION
automatically send request for cloudfront cookies when adding layer to
map and periodically every 24 hours.