### PR TITLE
Limit layers names size

### DIFF
--- a/src/leaflet-fixes.css
+++ b/src/leaflet-fixes.css
@@ -12,3 +12,11 @@
     box-shadow: 0 1px 5px rgba(0,0,0,0.65) !important;
 }
 
+.leaflet-control-layers label input + span {
+    display: inline-block;
+    max-width: 250px;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+    vertical-align: bottom;
+}
+

--- a/src/lib/leaflet.control.layers.configure/index.js
+++ b/src/lib/leaflet.control.layers.configure/index.js
@@ -294,8 +294,8 @@ function enableConfig(control, {layers, customLayersOrder}) {
 <p><a class="doc-link" href="https://leafletjs.com/reference-1.0.3.html#tilelayer" target="_blank">See Leaflet TileLayer documentation for url format</a></p>
 <label>Layer name<br/>
 <span class="hint">Maximum 40 characters</span><br/>
-<input maxlength="40" style="width: 100%" data-bind="value: name"/></label><br/>
-<label>Tile url template<br/><textarea data-bind="value: url" style="width: 100%"></textarea></label><br/>
+<input maxlength="40" class="layer-name" data-bind="value: name"/></label><br/>
+<label>Tile url template<br/><textarea data-bind="value: url" class="layer-url"></textarea></label><br/>
 <label><input type="radio" name="overlay" data-bind="checked: isOverlay, checkedValue: false">Base layer</label><br/>
 <label><input type="radio" name="overlay" data-bind="checked: isOverlay, checkedValue: true">Overlay</label><br/>
 <hr/>

--- a/src/lib/leaflet.control.layers.configure/index.js
+++ b/src/lib/leaflet.control.layers.configure/index.js
@@ -292,7 +292,9 @@ function enableConfig(control, {layers, customLayersOrder}) {
 /* eslint-disable max-len */
                 const formHtml = `
 <p><a class="doc-link" href="https://leafletjs.com/reference-1.0.3.html#tilelayer" target="_blank">See Leaflet TileLayer documentation for url format</a></p>
-<label>Layer name<br/><input data-bind="value: name"/></label><br/>
+<label>Layer name<br/>
+<span class="hint">Maximum 40 characters</span><br/>
+<input maxlength="40" style="width: 100%" data-bind="value: name"/></label><br/>
 <label>Tile url template<br/><textarea data-bind="value: url" style="width: 100%"></textarea></label><br/>
 <label><input type="radio" name="overlay" data-bind="checked: isOverlay, checkedValue: false">Base layer</label><br/>
 <label><input type="radio" name="overlay" data-bind="checked: isOverlay, checkedValue: true">Overlay</label><br/>

--- a/src/lib/leaflet.control.layers.configure/style.css
+++ b/src/lib/leaflet.control.layers.configure/style.css
@@ -126,6 +126,11 @@
     box-sizing: border-box;
 }
 
+.custom-layers-window .layer-name,
+.custom-layers-window .layer-url {
+    width: 100%;
+}
+
 .custom-layers-window .button:hover {
     background-color: #f4f4f4;
 }

--- a/src/lib/leaflet.control.layers.configure/style.css
+++ b/src/lib/leaflet.control.layers.configure/style.css
@@ -157,3 +157,8 @@
     border: none;
     border-top: 1px solid hsl(0, 0%, 85%);
 }
+
+.custom-layers-window .hint {
+    font-size: 10px;
+    color: #777;
+}


### PR DESCRIPTION
1. Limit display width in Layers control
2. Limit size accepted by input element.

Fixes #362 