### PR TITLE
custom layers: support for CRS EPSG:3395 #384

### DIFF
--- a/src/lib/leaflet.control.layers.configure/customLayer.js
+++ b/src/lib/leaflet.control.layers.configure/customLayer.js
@@ -29,4 +29,34 @@ L.Layer.CustomLayer = L.TileLayer.extend({
         return new L.Layer.CustomLayer(this._url, L.Util.extend({}, this.options, options));
     },
 
+    getCrs: function() {
+        return this.options.epsg3395 ? L.CRS.EPSG3395 : L.CRS.EPSG3857;
+    },
+
+    _getTilePos: function(coords) {
+        const tilePosLatLng = this.getCrs().pointToLatLng(coords.scaleBy(this.getTileSize()), coords.z);
+        return this._map.project(tilePosLatLng, coords.z).subtract(this._level.origin).round();
+    },
+
+    _pxBoundsToTileRange: function(bounds) {
+        const zoom = this._tileZoom;
+        const bounds2 = new L.Bounds(
+            this.getCrs().latLngToPoint(this._map.unproject(bounds.min, zoom), zoom),
+            this.getCrs().latLngToPoint(this._map.unproject(bounds.max, zoom), zoom));
+        return L.TileLayer.prototype._pxBoundsToTileRange.call(this, bounds2);
+    },
+
+    createTile: function(coords, done) {
+        const tile = L.TileLayer.prototype.createTile.call(this, coords, done);
+        const coordsBelow = L.point(coords).add([0, 1]);
+        coordsBelow.z = coords.z;
+        tile._adjustHeight = this._getTilePos(coordsBelow).y - this._getTilePos(coords).y;
+        return tile;
+    },
+
+    _initTile: function(tile) {
+        L.TileLayer.prototype._initTile.call(this, tile);
+        tile.style.height = `${tile._adjustHeight}px`;
+    }
+
 });

--- a/src/lib/leaflet.control.layers.configure/index.js
+++ b/src/lib/leaflet.control.layers.configure/index.js
@@ -185,7 +185,8 @@ function enableConfig(control, {layers, customLayersOrder}) {
                         maxZoom: 18,
                         isOverlay: false,
                         scaleDependent: false,
-                        isTop: true
+                        isTop: true,
+                        epsg3395: false
                     }
                 );
             },
@@ -274,6 +275,7 @@ function enableConfig(control, {layers, customLayersOrder}) {
                     maxZoom: ko.observable(fieldValues.maxZoom),
                     isOverlay: ko.observable(fieldValues.isOverlay),
                     isTop: ko.observable(fieldValues.isTop),
+                    epsg3395: ko.observable(fieldValues.epsg3395),
                     buttons: buttons,
                     buttonClicked: function buttonClicked(callbackN) {
                         const fieldValues = {
@@ -283,7 +285,8 @@ function enableConfig(control, {layers, customLayersOrder}) {
                             scaleDependent: dialogModel.scaleDependent(),
                             maxZoom: dialogModel.maxZoom(),
                             isOverlay: dialogModel.isOverlay(),
-                            isTop: dialogModel.isTop()
+                            isTop: dialogModel.isTop(),
+                            epsg3395: dialogModel.epsg3395()
                         };
                         buttons[callbackN].callback(fieldValues);
                     }
@@ -306,6 +309,7 @@ function enableConfig(control, {layers, customLayersOrder}) {
 <hr/>
 <label><input type="checkbox" data-bind="checked: scaleDependent"/>Content depends on scale(like OSM or Google maps)</label><br/>
 <label><input type="checkbox" data-bind="checked: tms" />TMS rows order</label><br />
+<label><input type="checkbox" data-bind="checked: epsg3395" />EPSG:3395</label><br />
 
 <label>Max zoom<br>
 <select data-bind="options: [9,10,11,12,13,14,15,16,17,18], value: maxZoom"></select></label>
@@ -408,7 +412,8 @@ function enableConfig(control, {layers, customLayersOrder}) {
                         jnx: true,
                         code: serialized,
                         noCors: true,
-                        isTop: fieldValues.isTop
+                        isTop: fieldValues.isTop,
+                        epsg3395: fieldValues.epsg3395
                     }
                 );
 


### PR DESCRIPTION
Я конечно не настоящий JS-разработчик, но добавил поддержку EPSG:3395 по аналогии с тем, как это сделано в src/lib/leaflet.layer.yandex/index.js