### PR TITLE
layers: update  hash state when layers added/removed on map

### DIFF
--- a/src/lib/leaflet.control.layers.configure/index.js
+++ b/src/lib/leaflet.control.layers.configure/index.js
@@ -476,6 +476,7 @@ function enableConfig(control, {layers, customLayersOrder}) {
                 this._customLayers.splice(layerPos, 0, newLayer);
                 if (
                     this._map.hasLayer(layer.layer) &&
+                    // turn off layer if changing from overlay to baselayer
                     (!layer.layer.options.isOverlay || newLayer.layer.options.isOverlay)
                 ) {
                     this._map.addLayer(newLayer.layer);

--- a/src/lib/leaflet.hashState/Leaflet.Control.Layers.js
+++ b/src/lib/leaflet.hashState/Leaflet.Control.Layers.js
@@ -4,7 +4,7 @@ import './leaflet.hashState';
 L.Control.Layers.include(L.Mixin.HashState);
 
 L.Control.Layers.include({
-        stateChangeEvents: ['baselayerchange', 'overlayadd', 'overlayremove'],
+        stateChangeEvents: ['layeradd', 'layerremove'],
         stateChangeEventsSource: '_map',
 
         serializeState: function() {


### PR DESCRIPTION
    Use generic map add/remove events instead of ones generated by layers
    control. Layers can be added and removed when editing custom layers and
    these do not produce layer control events.
    
    Fixes #664.
