### PR TITLE
github actions: explicitly install firefox latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
             firefox-version: '52.9.0esr'
             needs-xvfb: true
           - browser: FirefoxHeadless
+            firefox-version: 'latest'
           - browser: ChromeHeadless
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
For unknown reason tests can not find firefox anymore, if it is no specifically installed