### PR TITLE
build: do not update chalk to version 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "babel-loader": "^9.1.2",
     "babel-plugin-rewire": "^1.2.0",
     "chai": "^4.3.7",
-    "chalk": "^4.1.1",
+    "chalk": "<5.0.0",
     "child_process": "^1.0.2",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^11.0.0",


### PR DESCRIPTION
It has new import system which is not compatible with existing build script