### PR TITLE
update geocaching.su cache URL

### DIFF
--- a/src/lib/leaflet.layer.geocaching-su/index.js
+++ b/src/lib/leaflet.layer.geocaching-su/index.js
@@ -68,7 +68,7 @@ const GeocachingSu = L.Layer.CanvasMarkers.extend({
     },
 
     openCachePage: function(e) {
-        const url = `https://geocaching.su/?pn=101&cid=${e.marker.cacheId}`;
+        const url = `https://geocaching.su/cache/${e.marker.cacheId}`;
         openPopupWindow(url, 900, 'geocaching_su');
     }
 });


### PR DESCRIPTION
There was URL restructure at geocaching.su, while old links still work, let's use new up-to-date ones.