### PR TITLE
panoramas: fix bug: wikimedia photos have low resolution

### DIFF
--- a/src/lib/leaflet.control.panoramas/lib/wikimedia/index.js
+++ b/src/lib/leaflet.control.panoramas/lib/wikimedia/index.js
@@ -86,7 +86,7 @@ function parseSearchResponse(resp) { // eslint-disable-line complexity
             // original images can be rotated, 90 degrees
             // thumbnails are always oriented right
             // so we request thumbnail of original image size
-            let url = iinfo.thumburl.replace('134px', `${iinfo.width}px`);
+            let url = iinfo.thumburl.replace(/\/(134|250)px-/u, `/${iinfo.width}px-`);
             images.push({
                 url,
                 width: iinfo.width,


### PR DESCRIPTION
Thumbnail size was changed from 134 to 250 px, not sure if intentionally or accidentally, as iinfo.thumbwidth did not change. So now handling both variants.