### PR TITLE
panoramas - fix wikimedia photos window size.

### DIFF
--- a/src/lib/leaflet.map.sidebars/style.css
+++ b/src/lib/leaflet.map.sidebars/style.css
@@ -14,6 +14,7 @@
     display: flex;
     flex-direction: column;
     flex-grow: 1;
+    min-width: 0;
 }
 
 .leaflet-map-container-with-sidebars {


### PR DESCRIPTION
In Chrome, when panoramas are above map, on small (mobile) screens, and more than 9 photos available, then scroll is not enabled for buttons and no right navigation arrow is visible.
The problem is that the middle layout column has minimum size of 470px. I do not know where this value comes from, and it is not so in Firefox.