### PR TITLE
tests: fix test for garmin connect

### DIFF
--- a/test/track_load_data/testcases/garmin_connect_route_not_exists.json
+++ b/test/track_load_data/testcases/garmin_connect_route_not_exists.json
@@ -1,4 +1,4 @@
 {
-    "query": ["https://connect.garmin.com/modern/course/392833831"],
+    "query": ["https://connect.garmin.com/modern/course/3928338311"],
     "geodata": [{"error": "Garmin Connect route does not exist"}]
 }


### PR DESCRIPTION
Seems like track id used for testing non-existant track is now used for some private track.
Fixed by changing to another non-existing id.